### PR TITLE
 PR : ExhibitionRepository에서 잘못된 클래스 타입 수정

### DIFF
--- a/src/main/java/com/prgrms/artzip/exibition/domain/repository/ExhibitionRepository.java
+++ b/src/main/java/com/prgrms/artzip/exibition/domain/repository/ExhibitionRepository.java
@@ -1,7 +1,8 @@
 package com.prgrms.artzip.exibition.domain.repository;
 
+import com.prgrms.artzip.exibition.domain.Exhibition;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ExhibitionRepository extends JpaRepository<Exception, Long> {
+public interface ExhibitionRepository extends JpaRepository<Exhibition, Long> {
 
 }


### PR DESCRIPTION
## 구현 내용
### 잘못된 클래스 타입 수정
ExhibitionRepository에서 엔티티 타입이 Exception으로 잘못 표시되어 Exhibition으로 교체
