### PR TITLE
Review 도메인의 엔티티 값 검증 로직 수정 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/prgrms/artzip/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/artzip/common/ErrorCode.java
@@ -44,9 +44,12 @@ public enum ErrorCode {
   INVALID_REVIEW_CONTENT_LENGTH(400, "R002", "리뷰 내용은 리뷰 내용은 1글자 이상 1000자 이하이어야 합니다."),
   INVALID_REVIEW_TITLE_LENGTH(400, "R003", "리뷰 내용은 리뷰 제목은 1글자 이상 50자 이하이어야 합니다."),
   INVALID_REVIEW_DATE(400, "R004", "방문일은 오늘 이후일 수 없습니다."),
-  REVIEW_LIKE_FIELD_CONTAINS_NULL_VALUE(400, "R005", "리뷰 좋아요 필드에 NULL값이 포함되어 있습니다.");
-
+  REVIEW_LIKE_FIELD_CONTAINS_NULL_VALUE(400, "R005", "리뷰 좋아요 필드에 NULL값이 포함되어 있습니다."),
+  REVIEW_PHOTO_FIELD_CONTAINS_NULL_VALUE(400, "R006", "리뷰 사진 필드에 NULL값이 포함되어 있습니다."),
+  INVALID_REVIEW_PHOTO_PATH_LENGTH(400, "R007", "path는 1글자 이상 2083자 이하이어야 합니다.")
   ;
+
+
   private final int status;
   private final String code;
   private final String message;

--- a/src/main/java/com/prgrms/artzip/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/artzip/common/ErrorCode.java
@@ -35,8 +35,17 @@ public enum ErrorCode {
    */
   COMMENT_NOT_FOUND(400, "C001", "댓글이 존재하지 않습니다."),
   CONTENT_IS_REQUIRED(400, "C002", "댓글 내용은 필수입니다.(최대 500자)"),
-  CONTENT_IS_TOO_LONG(400, "C003", "댓글은 최대 500자입니다.")
-;
+  CONTENT_IS_TOO_LONG(400, "C003", "댓글은 최대 500자입니다."),
+
+  /**
+   * Review Domain
+   */
+  REVIEW_FIELD_CONTAINS_NULL_VALUE(400, "R001", "리뷰 필드에 NULL값이 포함되어 있습니다."),
+  INVALID_REVIEW_CONTENT_LENGTH(400, "R002", "리뷰 내용은 리뷰 내용은 1글자 이상 1000자 이하이어야 합니다."),
+  INVALID_REVIEW_TITLE_LENGTH(400, "R003", "리뷰 내용은 리뷰 제목은 1글자 이상 50자 이하이어야 합니다."),
+  INVALID_REVIEW_DATE(400, "R004", "방문일은 오늘 이후일 수 없습니다.")
+
+  ;
   private final int status;
   private final String code;
   private final String message;

--- a/src/main/java/com/prgrms/artzip/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/artzip/common/ErrorCode.java
@@ -41,8 +41,8 @@ public enum ErrorCode {
    * Review Domain
    */
   REVIEW_FIELD_CONTAINS_NULL_VALUE(400, "R001", "리뷰 필드에 NULL값이 포함되어 있습니다."),
-  INVALID_REVIEW_CONTENT_LENGTH(400, "R002", "리뷰 내용은 리뷰 내용은 1글자 이상 1000자 이하이어야 합니다."),
-  INVALID_REVIEW_TITLE_LENGTH(400, "R003", "리뷰 내용은 리뷰 제목은 1글자 이상 50자 이하이어야 합니다."),
+  INVALID_REVIEW_CONTENT_LENGTH(400, "R002", "리뷰 내용은 1글자 이상 1000자 이하이어야 합니다."),
+  INVALID_REVIEW_TITLE_LENGTH(400, "R003", "리뷰 제목은 1글자 이상 50자 이하이어야 합니다."),
   INVALID_REVIEW_DATE(400, "R004", "방문일은 오늘 이후일 수 없습니다."),
   REVIEW_LIKE_FIELD_CONTAINS_NULL_VALUE(400, "R005", "리뷰 좋아요 필드에 NULL값이 포함되어 있습니다."),
   REVIEW_PHOTO_FIELD_CONTAINS_NULL_VALUE(400, "R006", "리뷰 사진 필드에 NULL값이 포함되어 있습니다."),

--- a/src/main/java/com/prgrms/artzip/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/artzip/common/ErrorCode.java
@@ -43,7 +43,8 @@ public enum ErrorCode {
   REVIEW_FIELD_CONTAINS_NULL_VALUE(400, "R001", "리뷰 필드에 NULL값이 포함되어 있습니다."),
   INVALID_REVIEW_CONTENT_LENGTH(400, "R002", "리뷰 내용은 리뷰 내용은 1글자 이상 1000자 이하이어야 합니다."),
   INVALID_REVIEW_TITLE_LENGTH(400, "R003", "리뷰 내용은 리뷰 제목은 1글자 이상 50자 이하이어야 합니다."),
-  INVALID_REVIEW_DATE(400, "R004", "방문일은 오늘 이후일 수 없습니다.")
+  INVALID_REVIEW_DATE(400, "R004", "방문일은 오늘 이후일 수 없습니다."),
+  REVIEW_LIKE_FIELD_CONTAINS_NULL_VALUE(400, "R005", "리뷰 좋아요 필드에 NULL값이 포함되어 있습니다.");
 
   ;
   private final int status;

--- a/src/main/java/com/prgrms/artzip/review/domain/Review.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/Review.java
@@ -1,9 +1,12 @@
 package com.prgrms.artzip.review.domain;
 
+import com.prgrms.artzip.common.ErrorCode;
 import com.prgrms.artzip.common.entity.BaseEntity;
+import com.prgrms.artzip.common.error.exception.InvalidRequestException;
 import com.prgrms.artzip.exibition.domain.Exhibition;
 import com.prgrms.artzip.user.domain.User;
 import java.time.LocalDate;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -17,7 +20,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.Assert;
 
 @Entity
 @Table(name = "review")
@@ -72,26 +74,36 @@ public class Review extends BaseEntity {
 
   private void validateNotNull(User user, Exhibition exhibition, String content, String title,
       LocalDate date, Boolean isPublic) {
-    Assert.notNull(user, "리뷰 작성자는 필수값입니다.");
-    Assert.notNull(exhibition, "전시회는 필수값입니다.");
-    Assert.notNull(content, "리뷰 내용은 필수값입니다.");
-    Assert.notNull(title, "리뷰 제목은 필수값입니다.");
-    Assert.notNull(date, "방문일은 필수값입니다.");
-    Assert.notNull(isPublic, "공개 여부는 필수값입니다.");
+    if (Objects.isNull(user)) {
+      throw new InvalidRequestException(ErrorCode.REVIEW_FIELD_CONTAINS_NULL_VALUE);
+    } else if (Objects.isNull(exhibition)) {
+      throw new InvalidRequestException(ErrorCode.REVIEW_FIELD_CONTAINS_NULL_VALUE);
+    } else if (Objects.isNull(content)) {
+      throw new InvalidRequestException(ErrorCode.REVIEW_FIELD_CONTAINS_NULL_VALUE);
+    } else if (Objects.isNull(title)) {
+      throw new InvalidRequestException(ErrorCode.REVIEW_FIELD_CONTAINS_NULL_VALUE);
+    } else if (Objects.isNull(date)) {
+      throw new InvalidRequestException(ErrorCode.REVIEW_FIELD_CONTAINS_NULL_VALUE);
+    } else if (Objects.isNull(isPublic)) {
+      throw new InvalidRequestException(ErrorCode.REVIEW_FIELD_CONTAINS_NULL_VALUE);
+    }
   }
 
   private void validateContent(String content) {
-    Assert.isTrue(content.length() > 0 && content.length() <= 1000,
-        "리뷰 내용은 1글자 이상 1000자 이하이어야 합니다.");
+    if (content.length() <= 0 && content.length() > 1000) {
+      throw new InvalidRequestException(ErrorCode.INVALID_REVIEW_CONTENT_LENGTH);
+    }
   }
 
   private void validateTitle(String title) {
-    Assert.isTrue(title.length() > 0 && title.length() <= 50,
-        "리뷰 제목은 1글자 이상 50자 이하이어야 합니다.");
+    if (content.length() <= 0 && content.length() > 50) {
+      throw new InvalidRequestException(ErrorCode.INVALID_REVIEW_CONTENT_LENGTH);
+    }
   }
 
   private void validateDate(LocalDate date) {
-    Assert.isTrue(date.compareTo(LocalDate.now()) <= 0,
-        "방문일은 오늘 이후일 수 없습니다.");
+    if (date.compareTo(LocalDate.now()) > 0) {
+      throw new InvalidRequestException(ErrorCode.INVALID_REVIEW_CONTENT_LENGTH);
+    }
   }
 }

--- a/src/main/java/com/prgrms/artzip/review/domain/Review.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/Review.java
@@ -90,20 +90,20 @@ public class Review extends BaseEntity {
   }
 
   private void validateContent(String content) {
-    if (content.length() <= 0 && content.length() > 1000) {
+    if (content.isBlank() || content.length() > 1000) {
       throw new InvalidRequestException(ErrorCode.INVALID_REVIEW_CONTENT_LENGTH);
     }
   }
 
   private void validateTitle(String title) {
-    if (content.length() <= 0 && content.length() > 50) {
-      throw new InvalidRequestException(ErrorCode.INVALID_REVIEW_CONTENT_LENGTH);
+    if (title.isBlank() || title.length() > 50) {
+      throw new InvalidRequestException(ErrorCode.INVALID_REVIEW_TITLE_LENGTH);
     }
   }
 
   private void validateDate(LocalDate date) {
     if (date.compareTo(LocalDate.now()) > 0) {
-      throw new InvalidRequestException(ErrorCode.INVALID_REVIEW_CONTENT_LENGTH);
+      throw new InvalidRequestException(ErrorCode.INVALID_REVIEW_DATE);
     }
   }
 }

--- a/src/main/java/com/prgrms/artzip/review/domain/ReviewLike.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/ReviewLike.java
@@ -1,7 +1,10 @@
 package com.prgrms.artzip.review.domain;
 
+import com.prgrms.artzip.common.ErrorCode;
 import com.prgrms.artzip.common.entity.BaseEntity;
+import com.prgrms.artzip.common.error.exception.InvalidRequestException;
 import com.prgrms.artzip.user.domain.User;
+import java.util.Objects;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -13,7 +16,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JoinColumnOrFormula;
-import org.springframework.util.Assert;
 
 @Entity
 @Table(name = "review_like")
@@ -48,7 +50,10 @@ public class ReviewLike extends BaseEntity {
   }
 
   private void validateFields(Review review, User user) {
-    Assert.notNull(review, "review는 필수값입니다.");
-    Assert.notNull(user, "user는 필수값입니다.");
+    if (Objects.isNull(review)) {
+      throw new InvalidRequestException(ErrorCode.REVIEW_LIKE_FIELD_CONTAINS_NULL_VALUE);
+    } else if (Objects.isNull(user)) {
+      throw new InvalidRequestException(ErrorCode.REVIEW_LIKE_FIELD_CONTAINS_NULL_VALUE);
+    }
   }
 }

--- a/src/main/java/com/prgrms/artzip/review/domain/ReviewPhoto.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/ReviewPhoto.java
@@ -55,7 +55,7 @@ public class ReviewPhoto extends BaseEntity {
   }
 
   private void validatePath(String path) {
-    if (path.length() <= 0 && path.length() > 2083) {
+    if (path.isBlank() || path.length() > 2083) {
       throw new InvalidRequestException(ErrorCode.INVALID_REVIEW_PHOTO_PATH_LENGTH);
     }
   }

--- a/src/main/java/com/prgrms/artzip/review/domain/ReviewPhoto.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/ReviewPhoto.java
@@ -1,6 +1,9 @@
 package com.prgrms.artzip.review.domain;
 
+import com.prgrms.artzip.common.ErrorCode;
 import com.prgrms.artzip.common.entity.BaseEntity;
+import com.prgrms.artzip.common.error.exception.InvalidRequestException;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -13,7 +16,6 @@ import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.Assert;
 
 @Entity
 @Table(name = "review_photo")
@@ -45,12 +47,16 @@ public class ReviewPhoto extends BaseEntity {
   }
 
   private void validateNotNull(Review review, String path) {
-    Assert.notNull(review, "review는 필수값입니다.");
-    Assert.notNull(path, "path는 필수값입니다.");
+    if (Objects.isNull(review)) {
+      throw new InvalidRequestException(ErrorCode.REVIEW_PHOTO_FIELD_CONTAINS_NULL_VALUE);
+    } else if (Objects.isNull(path)) {
+      throw new InvalidRequestException(ErrorCode.REVIEW_PHOTO_FIELD_CONTAINS_NULL_VALUE);
+    }
   }
 
   private void validatePath(String path) {
-    Assert.isTrue(path.length() > 0 && path.length() <= 2083,
-        "path는 1글자 이상 2083자 이하이어야 합니다.");
+    if (path.length() <= 0 && path.length() > 2083) {
+      throw new InvalidRequestException(ErrorCode.REVIEW_PHOTO_FIELD_CONTAINS_NULL_VALUE);
+    }
   }
 }

--- a/src/main/java/com/prgrms/artzip/review/domain/ReviewPhoto.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/ReviewPhoto.java
@@ -56,7 +56,7 @@ public class ReviewPhoto extends BaseEntity {
 
   private void validatePath(String path) {
     if (path.length() <= 0 && path.length() > 2083) {
-      throw new InvalidRequestException(ErrorCode.REVIEW_PHOTO_FIELD_CONTAINS_NULL_VALUE);
+      throw new InvalidRequestException(ErrorCode.INVALID_REVIEW_PHOTO_PATH_LENGTH);
     }
   }
 }

--- a/src/test/java/com/prgrms/artzip/review/domain/ReviewLikeTest.java
+++ b/src/test/java/com/prgrms/artzip/review/domain/ReviewLikeTest.java
@@ -1,0 +1,83 @@
+package com.prgrms.artzip.review.domain;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.prgrms.artzip.common.ErrorCode;
+import com.prgrms.artzip.common.error.exception.InvalidRequestException;
+import com.prgrms.artzip.exibition.domain.Area;
+import com.prgrms.artzip.exibition.domain.Exhibition;
+import com.prgrms.artzip.exibition.domain.Genre;
+import com.prgrms.artzip.exibition.domain.Location;
+import com.prgrms.artzip.exibition.domain.Period;
+import com.prgrms.artzip.user.domain.User;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ReviewLikeTest {
+
+  private User user = new User("test@example.com", "Emily");
+  private Exhibition exhibition = Exhibition.builder()
+      .seq(32)
+      .name("전시회 제목")
+      .period(new Period(
+          LocalDate.of(2022, 4, 11),
+          LocalDate.of(2022, 6, 2)))
+      .genre(Genre.FINEART)
+      .description("이것은 전시회 설명입니다.")
+      .location(Location.builder()
+          .latitude(36.22)
+          .longitude(128.02)
+          .area(Area.BUSAN)
+          .place("미술관")
+          .address("부산 동구 중앙대로 11")
+          .build())
+      .inquiry("문의처 정보")
+      .fee("성인 20,000원")
+      .thumbnail("https://www.example-thumbnail-image.png")
+      .url("https://www.example.com")
+      .placeUrl("https://www.place-example.com")
+      .build();
+
+  private Review review = Review.builder()
+      .user(user)
+      .exhibition(exhibition)
+      .content("이것은 리뷰 본문입니다.")
+      .title("이것은 리뷰 제목입니다.")
+      .date(LocalDate.now())
+      .isPublic(true)
+      .build();
+
+  @Nested
+  @DisplayName("ReviewLike entity 필드값 검증")
+  class ReviewLikeEntityFieldValueValidation {
+
+    @Nested
+    @DisplayName("null 값")
+    class ValidateNotNullTest {
+
+      @Test
+      @DisplayName("review가 null이면 InvalidRequestException 발생")
+      void reviewTest() {
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              new ReviewLike(null, user);
+            });
+        assertThat(exception.getErrorCode(), is(ErrorCode.REVIEW_LIKE_FIELD_CONTAINS_NULL_VALUE));
+      }
+
+      @Test
+      @DisplayName("user가 null이면 InvalidRequestException 발생")
+      void userTest() {
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              new ReviewLike(review, null);
+            });
+        assertThat(exception.getErrorCode(), is(ErrorCode.REVIEW_LIKE_FIELD_CONTAINS_NULL_VALUE));
+      }
+    }
+  }
+}

--- a/src/test/java/com/prgrms/artzip/review/domain/ReviewPhotoTest.java
+++ b/src/test/java/com/prgrms/artzip/review/domain/ReviewPhotoTest.java
@@ -1,0 +1,117 @@
+package com.prgrms.artzip.review.domain;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.prgrms.artzip.common.ErrorCode;
+import com.prgrms.artzip.common.error.exception.InvalidRequestException;
+import com.prgrms.artzip.exibition.domain.Area;
+import com.prgrms.artzip.exibition.domain.Exhibition;
+import com.prgrms.artzip.exibition.domain.Genre;
+import com.prgrms.artzip.exibition.domain.Location;
+import com.prgrms.artzip.exibition.domain.Period;
+import com.prgrms.artzip.user.domain.User;
+import java.time.LocalDate;
+import org.assertj.core.internal.bytebuddy.utility.RandomString;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ReviewPhotoTest {
+
+  private User user = new User("test@example.com", "Emily");
+  private Exhibition exhibition = Exhibition.builder()
+      .seq(32)
+      .name("전시회 제목")
+      .period(new Period(
+          LocalDate.of(2022, 4, 11),
+          LocalDate.of(2022, 6, 2)))
+      .genre(Genre.FINEART)
+      .description("이것은 전시회 설명입니다.")
+      .location(Location.builder()
+          .latitude(36.22)
+          .longitude(128.02)
+          .area(Area.BUSAN)
+          .place("미술관")
+          .address("부산 동구 중앙대로 11")
+          .build())
+      .inquiry("문의처 정보")
+      .fee("성인 20,000원")
+      .thumbnail("https://www.example-thumbnail-image.png")
+      .url("https://www.example.com")
+      .placeUrl("https://www.place-example.com")
+      .build();
+
+  private Review review = Review.builder()
+      .user(user)
+      .exhibition(exhibition)
+      .content("이것은 리뷰 본문입니다.")
+      .title("이것은 리뷰 제목입니다.")
+      .date(LocalDate.now())
+      .isPublic(true)
+      .build();
+
+  @Nested
+  @DisplayName("ReviewPhoto entity 필드값 검증")
+  class ReviewPhotoEntityFieldValueValidation {
+
+    @Nested
+    @DisplayName("null 값")
+    class ValidateNotNullTest {
+
+      @Test
+      @DisplayName("review가 null이면 InvalidRequestException 발생")
+      void reviewTest() {
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              new ReviewPhoto(null, "https://www.review-photo.example.png");
+            });
+        assertThat(exception.getErrorCode(), is(ErrorCode.REVIEW_PHOTO_FIELD_CONTAINS_NULL_VALUE));
+      }
+
+      @Test
+      @DisplayName("path가 null이면 InvalidRequestException 발생")
+      void userTest() {
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              new ReviewPhoto(review, null);
+            });
+        assertThat(exception.getErrorCode(), is(ErrorCode.REVIEW_PHOTO_FIELD_CONTAINS_NULL_VALUE));
+      }
+    }
+
+
+    @Nested
+    @DisplayName("String 빈 공백(white space)")
+    class ValidateWhiteSpaceTest {
+
+      @Test
+      @DisplayName("path가 빈 공백이면 InvalidRequestException이 발생")
+      void pathTest() {
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              new ReviewPhoto(review, " ");
+            });
+        assertThat(exception.getErrorCode(), is(ErrorCode.INVALID_REVIEW_PHOTO_PATH_LENGTH));
+      }
+    }
+
+    @Nested
+    @DisplayName("string length")
+    class ValidateStringLengthTest {
+
+      @Test
+      @DisplayName("path의 길이가 2083보다 크면 InvalidRequestException 발생")
+      void pathGreaterThanMaxValue() {
+        String path = RandomString.make(2084);
+
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              new ReviewPhoto(review, path);
+            });
+        assertThat(exception.getErrorCode(), is(ErrorCode.INVALID_REVIEW_PHOTO_PATH_LENGTH));
+      }
+    }
+  }
+}

--- a/src/test/java/com/prgrms/artzip/review/domain/ReviewTest.java
+++ b/src/test/java/com/prgrms/artzip/review/domain/ReviewTest.java
@@ -1,0 +1,267 @@
+package com.prgrms.artzip.review.domain;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.prgrms.artzip.common.ErrorCode;
+import com.prgrms.artzip.common.error.exception.InvalidRequestException;
+import com.prgrms.artzip.exibition.domain.Area;
+import com.prgrms.artzip.exibition.domain.Exhibition;
+import com.prgrms.artzip.exibition.domain.Genre;
+import com.prgrms.artzip.exibition.domain.Location;
+import com.prgrms.artzip.exibition.domain.Period;
+import com.prgrms.artzip.user.domain.User;
+import java.time.LocalDate;
+import org.assertj.core.internal.bytebuddy.utility.RandomString;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ReviewTest {
+
+  private User user = new User("test@example.com", "Emily");
+  private Exhibition exhibition = Exhibition.builder()
+      .seq(32)
+      .name("전시회 제목")
+      .period(new Period(
+          LocalDate.of(2022, 4, 11),
+          LocalDate.of(2022, 6, 2)))
+      .genre(Genre.FINEART)
+      .description("이것은 전시회 설명입니다.")
+      .location(Location.builder()
+          .latitude(36.22)
+          .longitude(128.02)
+          .area(Area.BUSAN)
+          .place("미술관")
+          .address("부산 동구 중앙대로 11")
+          .build())
+      .inquiry("문의처 정보")
+      .fee("성인 20,000원")
+      .thumbnail("https://www.example-thumbnail-image.png")
+      .url("https://www.example.com")
+      .placeUrl("https://www.place-example.com")
+      .build();
+
+  @Nested
+  @DisplayName("Review entity 필드값 검증")
+  class ReviewEntityFieldValueValidationTest {
+
+    @Nested
+    @DisplayName("null 값")
+    class ValidateNotNullTest {
+
+      @Test
+      @DisplayName("user가 null이면 InvalidRequestException이 발생")
+      void userTest() {
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              Review.builder()
+                  .user(null)
+                  .exhibition(exhibition)
+                  .content("이것은 리뷰 본문입니다.")
+                  .title("이것은 리뷰 제목입니다.")
+                  .date(LocalDate.now())
+                  .isPublic(true)
+                  .build();
+            });
+        assertThat(exception.getErrorCode(), is(ErrorCode.REVIEW_FIELD_CONTAINS_NULL_VALUE));
+      }
+
+      @Test
+      @DisplayName("exhibition이 null이면 InvalidRequestException이 발생")
+      void exhibitionTest() {
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              Review.builder()
+                  .user(user)
+                  .exhibition(null)
+                  .content("이것은 리뷰 본문입니다.")
+                  .title("이것은 리뷰 제목입니다.")
+                  .date(LocalDate.now())
+                  .isPublic(true)
+                  .build();
+            });
+        assertThat(exception.getErrorCode(), is(ErrorCode.REVIEW_FIELD_CONTAINS_NULL_VALUE));
+      }
+
+      @Test
+      @DisplayName("content가 null이면 InvalidRequestException이 발생")
+      void contentTest() {
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              Review.builder()
+                  .user(user)
+                  .exhibition(exhibition)
+                  .content(null)
+                  .title("이것은 리뷰 제목입니다.")
+                  .date(LocalDate.now())
+                  .isPublic(true)
+                  .build();
+            });
+        assertThat(exception.getErrorCode(), is(ErrorCode.REVIEW_FIELD_CONTAINS_NULL_VALUE));
+      }
+
+      @Test
+      @DisplayName("title이 null이면 InvalidRequestException이 발생")
+      void titleTest() {
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              Review.builder()
+                  .user(user)
+                  .exhibition(exhibition)
+                  .content("이것은 리뷰 본문입니다.")
+                  .title(null)
+                  .date(LocalDate.now())
+                  .isPublic(true)
+                  .build();
+            });
+        assertThat(exception.getErrorCode(), is(ErrorCode.REVIEW_FIELD_CONTAINS_NULL_VALUE));
+      }
+
+      @Test
+      @DisplayName("date가 null이면 InvalidRequestException이 발생")
+      void dateTest() {
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              Review.builder()
+                  .user(user)
+                  .exhibition(exhibition)
+                  .content("이것은 리뷰 본문입니다.")
+                  .title("이것은 리뷰 제목입니다.")
+                  .date(null)
+                  .isPublic(true)
+                  .build();
+            });
+        assertThat(exception.getErrorCode(), is(ErrorCode.REVIEW_FIELD_CONTAINS_NULL_VALUE));
+      }
+
+      @Test
+      @DisplayName("isPublic이 null이면 InvalidRequestException이 발생")
+      void isPublicTest() {
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              Review.builder()
+                  .user(user)
+                  .exhibition(exhibition)
+                  .content("이것은 리뷰 본문입니다.")
+                  .title("이것은 리뷰 제목입니다.")
+                  .date(LocalDate.now())
+                  .isPublic(null)
+                  .build();
+            });
+        assertThat(exception.getErrorCode(), is(ErrorCode.REVIEW_FIELD_CONTAINS_NULL_VALUE));
+      }
+    }
+
+    @Nested
+    @DisplayName("String 빈 공백(white space)")
+    class ValidateWhiteSpaceTest {
+
+      @Test
+      @DisplayName("content가 빈 공백이면 InvalidRequestException이 발생")
+      void contentTest() {
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              Review.builder()
+                  .user(user)
+                  .exhibition(exhibition)
+                  .content("  ")
+                  .title("이것은 리뷰 제목입니다.")
+                  .date(LocalDate.now())
+                  .isPublic(true)
+                  .build();
+            });
+        assertThat(exception.getErrorCode(), is(ErrorCode.INVALID_REVIEW_CONTENT_LENGTH));
+      }
+
+      @Test
+      @DisplayName("title이 빈 공백이면 InvalidRequestException이 발생")
+      void titleWhiteSpaceTest() {
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              Review.builder()
+                  .user(user)
+                  .exhibition(exhibition)
+                  .content("이것은 리뷰 본문입니다.")
+                  .title("    ")
+                  .date(LocalDate.now())
+                  .isPublic(true)
+                  .build();
+            });
+        assertThat(exception.getErrorCode(), is(ErrorCode.INVALID_REVIEW_TITLE_LENGTH));
+      }
+    }
+
+    @Nested
+    @DisplayName("string length")
+    class ValidateStringLengthTest {
+
+      @Test
+      @DisplayName("content의 길이가 1000보다 크면 InvalidRequestException 발생")
+      void contentGreaterThanMaxValue() {
+        String content = RandomString.make(1001);
+
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              Review.builder()
+                  .user(user)
+                  .exhibition(exhibition)
+                  .content(content)
+                  .title("이것은 리뷰 제목입니다.")
+                  .date(LocalDate.now())
+                  .isPublic(true)
+                  .build();
+            }
+        );
+        assertThat(exception.getErrorCode(), is(ErrorCode.INVALID_REVIEW_CONTENT_LENGTH));
+      }
+
+      @Test
+      @DisplayName("title의 길이가 51보다 크면 InvalidRequestException 발생")
+      void titleGreaterThanMaxValue() {
+        String title = RandomString.make(51);
+
+        InvalidRequestException exception = assertThrows(
+            InvalidRequestException.class, () -> {
+              Review.builder()
+                  .user(user)
+                  .exhibition(exhibition)
+                  .content("이것은 리뷰 본문입니다.")
+                  .title(title)
+                  .date(LocalDate.now())
+                  .isPublic(true)
+                  .build();
+            }
+        );
+        assertThat(exception.getErrorCode(), is(ErrorCode.INVALID_REVIEW_TITLE_LENGTH));
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("Date")
+  class ValidateDate {
+
+    @Test
+    @DisplayName("date가 오늘 이후이면 InvalidRequestException 발생")
+    void afterToday() {
+      LocalDate dayAfterToday = LocalDate.now().plusDays(1);
+
+      InvalidRequestException exception = assertThrows(
+          InvalidRequestException.class, () -> {
+            Review.builder()
+                .user(user)
+                .exhibition(exhibition)
+                .content("이것은 리뷰 본문입니다.")
+                .title("이것은 리뷰 제목입니다.")
+                .date(dayAfterToday)
+                .isPublic(true)
+                .build();
+          }
+      );
+      assertThat(exception.getErrorCode(), is(ErrorCode.INVALID_REVIEW_DATE));
+    }
+  }
+
+}


### PR DESCRIPTION
## 구현내용
### Review 도메인 엔티티(Review, ReviewLike, ReviewPhoto)의 값 검증 로직 수정
- 값 검증시 Assert 사용 대신 custom exception 사용
### Review 도메인 엔티티(Review, ReviewLike, ReviewPhoto)에 대한 테스트 코드 작성
- 필드값 검증하는 부분에 대한 테스트 코드 작성