### PR TITLE
exhibitionLike 수정

### DIFF
--- a/src/main/java/com/prgrms/artzip/exibition/controller/ExhibitionController.java
+++ b/src/main/java/com/prgrms/artzip/exibition/controller/ExhibitionController.java
@@ -15,7 +15,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -33,7 +32,7 @@ public class ExhibitionController {
   private final ExhibitionSearchService exhibitionSearchService;
 
   @ApiOperation(value = "다가오는 전시회 조회", notes = "다가오는 전시회를 조회합니다.")
-  @GetMapping("/upcoming")
+  // @GetMapping("/upcoming")
   public ResponseEntity<ApiResponse<PageResponse<ExhibitionInfo>>> getUpcomingExhibitions(
       @PageableDefault(page = 0, size = 10) Pageable pageable) {
     ApiResponse apiResponse = ApiResponse.builder()
@@ -48,7 +47,7 @@ public class ExhibitionController {
   }
 
   @ApiOperation(value = "인기 많은 전시회 조회", notes = "인기 많은 전시회를 조회합니다.")
-  @GetMapping("/mostlike")
+  // @GetMapping("/mostlike")
   public ResponseEntity<ApiResponse<PageResponse<ExhibitionInfo>>> getMostLikeExhibitions(
       @RequestParam(value = "include-end", required = false, defaultValue = "true") boolean includeEnd,
       @PageableDefault(page = 0, size = 10) Pageable pageable) {
@@ -65,7 +64,7 @@ public class ExhibitionController {
 
   // 수정 필요!
   @ApiOperation(value = "전시회 상세 조회", notes = "전시회를 조회합니다.")
-  @GetMapping("/{exhibitionId}")
+  // @GetMapping("/{exhibitionId}")
   public ResponseEntity<ApiResponse<ExhibitionDetailInfo>> getExhibition(
       @PathVariable Long exhibitionId) {
     ApiResponse apiResponse = ApiResponse.builder()
@@ -96,7 +95,7 @@ public class ExhibitionController {
   }
 
   @ApiOperation(value = "전시회 검색", notes = "전시회를 이름으로 검색합니다.")
-  @GetMapping
+  // @GetMapping
   public ResponseEntity<ApiResponse<PageResponse<ExhibitionInfo>>> getExhibitionByQuery(
       String query,
       @RequestParam(value = "include-end", required = false, defaultValue = "true") boolean includeEnd,

--- a/src/main/java/com/prgrms/artzip/exibition/domain/Exhibition.java
+++ b/src/main/java/com/prgrms/artzip/exibition/domain/Exhibition.java
@@ -15,6 +15,7 @@ import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHB_THUMBNAIL;
 import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHB_URL;
 import static java.util.Objects.isNull;
 import static javax.persistence.EnumType.STRING;
+import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 import static org.springframework.util.StringUtils.hasText;
 
@@ -35,7 +36,6 @@ import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
@@ -50,7 +50,7 @@ import lombok.NoArgsConstructor;
 public class Exhibition extends BaseEntity {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @GeneratedValue(strategy = IDENTITY)
   @Column(name = "exhibition_id")
   private Long id;
 

--- a/src/main/java/com/prgrms/artzip/exibition/domain/ExhibitionLike.java
+++ b/src/main/java/com/prgrms/artzip/exibition/domain/ExhibitionLike.java
@@ -3,36 +3,50 @@ package com.prgrms.artzip.exibition.domain;
 import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHB_LIKE;
 import static java.util.Objects.isNull;
 import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+import com.prgrms.artzip.common.entity.BaseEntity;
 import com.prgrms.artzip.common.error.exception.InvalidRequestException;
 import com.prgrms.artzip.user.domain.User;
-import javax.persistence.EmbeddedId;
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.MapsId;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(
+    name = "exhibition_like",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "unq_exhibition_like_exhibition_id_user_id",
+            columnNames = {"exhibition_id", "user_id"}
+        )
+    }
+)
 @NoArgsConstructor(access = PROTECTED)
-public class ExhibitionLike {
-  @EmbeddedId
-  private ExhibitionLikeId exhibitionLikeId;
+public class ExhibitionLike extends BaseEntity {
 
-  @MapsId("exhibitionId")
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  @Column(name = "exhibitionlike_id")
+  private Long id;
+
   @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "exhibition_id", referencedColumnName = "exhibition_id")
   private Exhibition exhibition;
 
-  @MapsId("userId")
   @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "user_id", referencedColumnName = "user_id")
   private User user;
 
   public ExhibitionLike(Exhibition exhibition, User user) {
     validateExhibitionLikeField(exhibition, user);
-    this.exhibitionLikeId = new ExhibitionLikeId(exhibition.getId(), user.getId());
     setExhibition(exhibition);
     setUser(user);
   }
@@ -47,7 +61,7 @@ public class ExhibitionLike {
   }
 
   private void validateExhibitionLikeField(Exhibition exhibition, User user) {
-    if(isNull(exhibition) || isNull(user)) {
+    if (isNull(exhibition) || isNull(user)) {
       throw new InvalidRequestException(INVALID_EXHB_LIKE);
     }
   }

--- a/src/main/java/com/prgrms/artzip/exibition/domain/repository/ExhibitionLikeRepository.java
+++ b/src/main/java/com/prgrms/artzip/exibition/domain/repository/ExhibitionLikeRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ExhibitionLikeRepository extends JpaRepository<ExhibitionLike, ExhibitionLikeId> {
-  @Query("SELECT COUNT(EL) from ExhibitionLike EL WHERE EL.exhibitionLikeId.exhibitionId = :exhibitionId")
+
+  @Query("SELECT COUNT(EL) from ExhibitionLike EL WHERE EL.exhibition.id = :exhibitionId")
   Long countByExhibitionId(@Param("exhibitionId") Long exhibitionId);
 }

--- a/src/main/java/com/prgrms/artzip/exibition/domain/repository/ExhibitionLikeRepository.java
+++ b/src/main/java/com/prgrms/artzip/exibition/domain/repository/ExhibitionLikeRepository.java
@@ -1,13 +1,17 @@
 package com.prgrms.artzip.exibition.domain.repository;
 
 import com.prgrms.artzip.exibition.domain.ExhibitionLike;
-import com.prgrms.artzip.exibition.domain.ExhibitionLikeId;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface ExhibitionLikeRepository extends JpaRepository<ExhibitionLike, ExhibitionLikeId> {
+public interface ExhibitionLikeRepository extends JpaRepository<ExhibitionLike, Long> {
 
   @Query("SELECT COUNT(EL) from ExhibitionLike EL WHERE EL.exhibition.id = :exhibitionId")
   Long countByExhibitionId(@Param("exhibitionId") Long exhibitionId);
+
+  @Query("SELECT EL from ExhibitionLike EL WHERE EL.exhibition.id = :exhibitionId and EL.user.id = :userId")
+  Optional<ExhibitionLike> findByExhibitionIdAndUserId(@Param("exhibitionId") Long exhibitionId,
+      @Param("userId") Long userId);
 }

--- a/src/main/java/com/prgrms/artzip/exibition/service/ExhibitionLikeService.java
+++ b/src/main/java/com/prgrms/artzip/exibition/service/ExhibitionLikeService.java
@@ -5,11 +5,11 @@ import static com.prgrms.artzip.common.ErrorCode.EXHB_NOT_FOUND;
 import com.prgrms.artzip.common.error.exception.InvalidRequestException;
 import com.prgrms.artzip.exibition.domain.Exhibition;
 import com.prgrms.artzip.exibition.domain.ExhibitionLike;
-import com.prgrms.artzip.exibition.domain.ExhibitionLikeId;
 import com.prgrms.artzip.exibition.domain.repository.ExhibitionLikeRepository;
 import com.prgrms.artzip.exibition.domain.repository.ExhibitionRepository;
 import com.prgrms.artzip.exibition.dto.response.ExhibitionLikeResult;
 import com.prgrms.artzip.user.domain.User;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,21 +17,25 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class ExhibitionLikeService {
+
   private final ExhibitionRepository exhibitionRepository;
   private final ExhibitionLikeRepository exhibitionLikeRepository;
 
   // 차후 수정 필요!
   @Transactional
   public ExhibitionLikeResult updateExhibitionLike(Long exhibitionId, User user) {
-    ExhibitionLikeId exhibitionLikeId = new ExhibitionLikeId(exhibitionId, user.getId());
-    boolean isLiked = exhibitionLikeRepository.findById(exhibitionLikeId).isPresent();
 
-    if(isLiked) {
-      exhibitionLikeRepository.deleteById(exhibitionLikeId);
-    }else {
-      Exhibition exhibition = exhibitionRepository.findById(exhibitionId).orElseThrow(() -> new InvalidRequestException(EXHB_NOT_FOUND));
+    Optional<ExhibitionLike> optionalExhibitionLike = exhibitionLikeRepository.findByExhibitionIdAndUserId(
+        exhibitionId, user.getId());
+
+    boolean isLiked = optionalExhibitionLike.isPresent();
+    optionalExhibitionLike.ifPresentOrElse(exhibitionLike -> {
+      exhibitionLikeRepository.delete(exhibitionLike);
+    }, () -> {
+      Exhibition exhibition = exhibitionRepository.findById(exhibitionId)
+          .orElseThrow(() -> new InvalidRequestException(EXHB_NOT_FOUND));
       exhibitionLikeRepository.save(new ExhibitionLike(exhibition, user));
-    }
+    });
 
     // jpql을 사용하기 때문에 flush
     Long likeCount = exhibitionLikeRepository.countByExhibitionId(exhibitionId);

--- a/src/main/java/com/prgrms/artzip/exibition/service/ExhibitionService.java
+++ b/src/main/java/com/prgrms/artzip/exibition/service/ExhibitionService.java
@@ -4,7 +4,6 @@ import static com.prgrms.artzip.common.ErrorCode.EXHB_NOT_FOUND;
 import static org.springframework.util.StringUtils.hasText;
 
 import com.prgrms.artzip.common.error.exception.InvalidRequestException;
-import com.prgrms.artzip.exibition.domain.ExhibitionLikeId;
 import com.prgrms.artzip.exibition.domain.repository.ExhibitionLikeRepository;
 import com.prgrms.artzip.exibition.domain.repository.ExhibitionRepository;
 import com.prgrms.artzip.exibition.dto.projection.ExhibitionDetailForSimpleQuery;
@@ -44,7 +43,7 @@ public class ExhibitionService {
 
     boolean isLiked = false;
     if (user != null) {
-      isLiked = exhibitionLikeRepository.findById(new ExhibitionLikeId(exhibitionId, user.getId()))
+      isLiked = exhibitionLikeRepository.findByExhibitionIdAndUserId(exhibitionId, user.getId())
           .isPresent();
     }
 

--- a/src/test/java/com/prgrms/artzip/exibition/service/ExhibitionLikeServiceTest.java
+++ b/src/test/java/com/prgrms/artzip/exibition/service/ExhibitionLikeServiceTest.java
@@ -11,7 +11,6 @@ import com.prgrms.artzip.common.Authority;
 import com.prgrms.artzip.common.error.exception.InvalidRequestException;
 import com.prgrms.artzip.exibition.domain.Exhibition;
 import com.prgrms.artzip.exibition.domain.ExhibitionLike;
-import com.prgrms.artzip.exibition.domain.ExhibitionLikeId;
 import com.prgrms.artzip.exibition.domain.enumType.Area;
 import com.prgrms.artzip.exibition.domain.enumType.Genre;
 import com.prgrms.artzip.exibition.domain.repository.ExhibitionLikeRepository;
@@ -68,19 +67,18 @@ class ExhibitionLikeServiceTest {
   @Test
   @DisplayName("좋아요 추가시 전시회가 없는 경우 테스트")
   void testAddLikeExhibitionNotFound() {
-    ExhibitionLikeId exhibitionLikeId = new ExhibitionLikeId(exhibitionId, user.getId());
-
-    when(exhibitionLikeRepository.findById(exhibitionLikeId)).thenReturn(Optional.empty());
+    when(exhibitionLikeRepository.findByExhibitionIdAndUserId(exhibitionId,
+        user.getId())).thenReturn(Optional.empty());
     when(exhibitionRepository.findById(exhibitionId)).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> exhibitionLikeService.updateExhibitionLike(exhibitionId, user))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessage("존재하지 않는 전시회 입니다.");
 
-    verify(exhibitionLikeRepository).findById(exhibitionLikeId);
+    verify(exhibitionLikeRepository).findByExhibitionIdAndUserId(exhibitionId, user.getId());
     verify(exhibitionRepository).findById(exhibitionId);
 
-    verify(exhibitionLikeRepository, never()).deleteById(exhibitionLikeId);
+    verify(exhibitionLikeRepository, never()).delete(any());
     verify(exhibitionLikeRepository, never()).save(any());
     verify(exhibitionLikeRepository, never()).countByExhibitionId(exhibitionId);
   }
@@ -88,41 +86,40 @@ class ExhibitionLikeServiceTest {
   @Test
   @DisplayName("좋아요 추가 테스트")
   void testAddLike() {
-    ExhibitionLikeId exhibitionLikeId = new ExhibitionLikeId(exhibitionId, user.getId());
-
-    when(exhibitionLikeRepository.findById(exhibitionLikeId)).thenReturn(Optional.empty());
-    when(exhibitionRepository.findById(exhibitionId)).thenReturn(Optional.of(exhibition));
-    when(exhibitionLikeRepository.countByExhibitionId(exhibitionId)).thenReturn(100L);
+    when(exhibitionLikeRepository.findByExhibitionIdAndUserId(exhibitionId, user.getId()))
+        .thenReturn(Optional.empty());
+    when(exhibitionRepository.findById(exhibitionId))
+        .thenReturn(Optional.of(exhibition));
+    when(exhibitionLikeRepository.countByExhibitionId(exhibitionId))
+        .thenReturn(100L);
 
     ExhibitionLikeResult exhibitionLikeResult = exhibitionLikeService.updateExhibitionLike(
         exhibitionId, user);
 
-    verify(exhibitionLikeRepository).findById(exhibitionLikeId);
+    verify(exhibitionLikeRepository).findByExhibitionIdAndUserId(exhibitionId, user.getId());
     verify(exhibitionRepository).findById(exhibitionId);
     verify(exhibitionLikeRepository).save(any());
     verify(exhibitionLikeRepository).countByExhibitionId(exhibitionId);
-
-    verify(exhibitionLikeRepository, never()).deleteById(exhibitionLikeId);
+    verify(exhibitionLikeRepository, never()).delete(any());
 
     assertThat(exhibitionLikeResult.getIsLiked()).isTrue();
   }
 
-
   @Test
   @DisplayName("좊아요 삭제")
   void testRemoveLike() {
-    ExhibitionLikeId exhibitionLikeId = new ExhibitionLikeId(exhibitionId, user.getId());
     ExhibitionLike exhibitionLike = new ExhibitionLike(exhibition, user);
 
-    when(exhibitionLikeRepository.findById(exhibitionLikeId)).thenReturn(
-        Optional.of(exhibitionLike));
-    when(exhibitionLikeRepository.countByExhibitionId(exhibitionId)).thenReturn(100L);
+    when(exhibitionLikeRepository.findByExhibitionIdAndUserId(exhibitionId, user.getId()))
+        .thenReturn(Optional.of(exhibitionLike));
+    when(exhibitionLikeRepository.countByExhibitionId(exhibitionId))
+        .thenReturn(100L);
 
     ExhibitionLikeResult exhibitionLikeResult = exhibitionLikeService.updateExhibitionLike(
         exhibitionId, user);
 
-    verify(exhibitionLikeRepository).findById(exhibitionLikeId);
-    verify(exhibitionLikeRepository).deleteById(exhibitionLikeId);
+    verify(exhibitionLikeRepository).findByExhibitionIdAndUserId(exhibitionId, user.getId());
+    verify(exhibitionLikeRepository).delete(exhibitionLike);
     verify(exhibitionLikeRepository).countByExhibitionId(exhibitionId);
 
     verify(exhibitionRepository, never()).findById(exhibitionId);

--- a/src/test/java/com/prgrms/artzip/exibition/service/ExhibitionServiceTest.java
+++ b/src/test/java/com/prgrms/artzip/exibition/service/ExhibitionServiceTest.java
@@ -11,7 +11,6 @@ import com.prgrms.artzip.common.Authority;
 import com.prgrms.artzip.common.error.exception.InvalidRequestException;
 import com.prgrms.artzip.exibition.domain.Exhibition;
 import com.prgrms.artzip.exibition.domain.ExhibitionLike;
-import com.prgrms.artzip.exibition.domain.ExhibitionLikeId;
 import com.prgrms.artzip.exibition.domain.enumType.Area;
 import com.prgrms.artzip.exibition.domain.enumType.Genre;
 import com.prgrms.artzip.exibition.domain.repository.ExhibitionLikeRepository;
@@ -198,28 +197,27 @@ class ExhibitionServiceTest {
     @Test
     @DisplayName("인증된 사용자이며 좋아요를 누른 경우")
     void testAuthorizedLike() {
-      when(exhibitionRepository.findExhibition(exhibitionId)).thenReturn(
-          Optional.of(exhibitionDetail1));
-      when(exhibitionLikeRepository.findById(
-          new ExhibitionLikeId(exhibitionId, user.getId()))).thenReturn(
-          Optional.of(exhibitionLike));
+      when(exhibitionRepository.findExhibition(exhibitionId))
+          .thenReturn(Optional.of(exhibitionDetail1));
+      when(exhibitionLikeRepository.findByExhibitionIdAndUserId(exhibitionId, user.getId()))
+          .thenReturn(Optional.of(exhibitionLike));
 
       exhibitionService.getExhibition(exhibitionId, user);
 
-      verify(exhibitionLikeRepository).findById(new ExhibitionLikeId(exhibitionId, user.getId()));
+      verify(exhibitionLikeRepository).findByExhibitionIdAndUserId(exhibitionId, user.getId());
     }
 
     @Test
     @DisplayName("인증된 사용자이며 좋아요를 누르지 않은 경우")
     void testAuthorizedNotLike() {
-      when(exhibitionRepository.findExhibition(exhibitionId)).thenReturn(
-          Optional.of(exhibitionDetail2));
-      when(exhibitionLikeRepository.findById(
-          new ExhibitionLikeId(exhibitionId, user.getId()))).thenReturn(Optional.empty());
+      when(exhibitionRepository.findExhibition(exhibitionId))
+          .thenReturn(Optional.of(exhibitionDetail2));
+      when(exhibitionLikeRepository.findByExhibitionIdAndUserId(exhibitionId, user.getId()))
+          .thenReturn(Optional.empty());
 
       exhibitionService.getExhibition(exhibitionId, user);
 
-      verify(exhibitionLikeRepository).findById(new ExhibitionLikeId(exhibitionId, user.getId()));
+      verify(exhibitionLikeRepository).findByExhibitionIdAndUserId(exhibitionId, user.getId());
     }
   }
 }


### PR DESCRIPTION
## 구현 내용
### exhibitionLike 수정
* exhibitionLike 엔티티가 수정 되었습니다.
  * 복합키를 제거하고 일반 PK를 사용하도록 변경하였습니다.
  * created 필드와 updated_at 필드가 추가되었습니다.
    * updated_at의 경우 BaseEntity를 사용하다보니 추가하게 되었습니다.
* 엔티티 수정에 따른 service와 repository 코드가 수정되었습니다.
* 수정된 코드에 따른 테스트 코드를 작성하였습니다.

### ExhibitionController에 대한 RequestMapping 차단
* DB와 조회 커리에 문제가 있어 일단 요청 매핑을 막았습니다.
