### PR TITLE
Filter에서 예외 발생 시 예외 처리 구현, 유저 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/prgrms/artzip/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/artzip/common/ErrorCode.java
@@ -23,6 +23,8 @@ public enum ErrorCode {
   INVALID_FILE_EXTENSION(400, "C008", "올바르지 않은 파일 확장자입니다. (png, jpg, jpeg 가능)"),
   MAX_UPLOAD_SIZE_EXCEEDED(400, "C009", "최대 파일 크기(5MB)보다 큰 파일입니다."),
 
+  ACCESS_DENIED(403, "C010", "요청 권한이 없습니다."),
+
   /**
    * User Domain
    */

--- a/src/main/java/com/prgrms/artzip/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/artzip/common/ErrorCode.java
@@ -25,6 +25,8 @@ public enum ErrorCode {
 
   ACCESS_DENIED(403, "C010", "요청 권한이 없습니다."),
 
+  UNAUTHENTICATED_USER(401, "C011", "인증되지 않은 사용자입니다."),
+
   /**
    * User Domain
    */

--- a/src/main/java/com/prgrms/artzip/common/config/WebConfig.java
+++ b/src/main/java/com/prgrms/artzip/common/config/WebConfig.java
@@ -3,32 +3,36 @@ package com.prgrms.artzip.common.config;
 import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import javax.annotation.PostConstruct;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-  @Bean
-  public ObjectMapper objectMapper() {
-    ObjectMapper objectMapper = new ObjectMapper();
-    objectMapper.getFactory().configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), true);
-    objectMapper.registerModule(new JavaTimeModule());
-    return objectMapper;
-  }
-  @Override
-  public void addCorsMappings(CorsRegistry registry) {
-    registry.addMapping("/api/v1/**")
-        .allowedOriginPatterns("*")
-        .allowedMethods(
-            HttpMethod.GET.name(),
-            HttpMethod.HEAD.name(),
-            HttpMethod.POST.name(),
-            HttpMethod.PUT.name(),
-            HttpMethod.DELETE.name())
-        .allowCredentials(true);
-  }
+    private final ObjectMapper objectMapper;
+    @PostConstruct
+    public void initObjectMapper() {
+        objectMapper.getFactory().configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), true);
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/v1/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods(
+                        HttpMethod.GET.name(),
+                        HttpMethod.HEAD.name(),
+                        HttpMethod.POST.name(),
+                        HttpMethod.PUT.name(),
+                        HttpMethod.DELETE.name())
+                .allowCredentials(true);
+    }
 }

--- a/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
@@ -23,7 +23,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-@EnableWebSecurity
+@EnableWebSecurity(debug = true)
 @Configuration
 @EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
 public class WebSecurityConfig {

--- a/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.prgrms.artzip.common.config;
 
+import com.prgrms.artzip.common.Authority;
 import com.prgrms.artzip.common.jwt.Jwt;
 import com.prgrms.artzip.common.jwt.JwtAuthenticationFilter;
 import com.prgrms.artzip.common.jwt.JwtAuthenticationProvider;
@@ -13,6 +14,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -23,6 +25,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @EnableWebSecurity
 @Configuration
+@EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
 public class WebSecurityConfig {
     private final Logger log = LoggerFactory.getLogger(getClass());
     private final JwtConfig jwtConfig;
@@ -76,7 +79,9 @@ public class WebSecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/**").permitAll()
+                .antMatchers("/swagger*/**").permitAll()
+                .antMatchers("/api/**").permitAll()
+                .antMatchers("/api/v1/me/**").hasAuthority(Authority.USER.name())
                 .and()
                 .addFilterAfter(jwtAuthenticationFilter(jwtService, userUtilService), UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
@@ -120,6 +120,7 @@ public class WebSecurityConfig {
                 .antMatchers("/swagger*/**").permitAll()
                 .antMatchers("/api/v1/comments/**/children", "/api/v1/reviews/**/comments").permitAll()
                 .antMatchers("/api/v1/users/me/**").hasAnyAuthority(USER.name(), ADMIN.name())
+                .antMatchers("/api/v1/users/**/info").hasAnyAuthority(USER.name(), ADMIN.name())
                 .antMatchers("/api/v1/comments/**", "/api/v1/reviews/**/comments/new").hasAnyAuthority(USER.name(), ADMIN.name())
                 .anyRequest().permitAll()
                 .and()

--- a/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
@@ -2,9 +2,7 @@ package com.prgrms.artzip.common.config;
 
 import static com.prgrms.artzip.common.Authority.*;
 
-import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.prgrms.artzip.common.ErrorCode;
 import com.prgrms.artzip.common.ErrorResponse;
 import com.prgrms.artzip.common.filter.ExceptionHandlerFilter;

--- a/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
@@ -118,6 +118,7 @@ public class WebSecurityConfig {
                 .and()
                 .authorizeRequests()
                 .antMatchers("/swagger*/**").permitAll()
+                .antMatchers("/api/v1/comments/**/children", "/api/v1/reviews/**/comments").permitAll()
                 .antMatchers("/api/v1/users/me/**").hasAnyAuthority(USER.name(), ADMIN.name())
                 .antMatchers("/api/v1/comments/**", "/api/v1/reviews/**/comments/new").hasAnyAuthority(USER.name(), ADMIN.name())
                 .anyRequest().permitAll()

--- a/src/main/java/com/prgrms/artzip/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/artzip/common/error/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import com.prgrms.artzip.common.error.exception.PermissionDeniedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -56,6 +57,15 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(org.springframework.validation.BindException.class)
   public ResponseEntity<ErrorResponse> handleBindException(BindException e) {
     return handleException(e, ErrorCode.INVALID_INPUT_VALUE);
+  }
+
+  // 403 : Access Denied
+  @ExceptionHandler(AccessDeniedException.class)
+  public ResponseEntity<ErrorResponse> handleAccessDeniedException(
+          AccessDeniedException e) {
+    log.warn(e.getMessage(), e);
+    ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.ACCESS_DENIED);
+    return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
   }
 
   @ExceptionHandler(HttpMessageNotReadableException.class)

--- a/src/main/java/com/prgrms/artzip/common/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/prgrms/artzip/common/filter/ExceptionHandlerFilter.java
@@ -1,0 +1,47 @@
+package com.prgrms.artzip.common.filter;
+
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.artzip.common.ErrorCode;
+import com.prgrms.artzip.common.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@RequiredArgsConstructor
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (TokenExpiredException e) {
+            setErrorResponse(HttpStatus.UNAUTHORIZED, response, ErrorCode.TOKEN_EXPIRED);
+        } catch (RuntimeException e) {
+            setErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, response, ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public void setErrorResponse(HttpStatus status, HttpServletResponse response, ErrorCode errorCode) {
+        response.setStatus(status.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        try {
+            String json = objectMapper.writeValueAsString(ErrorResponse.of(errorCode));
+            PrintWriter writer = response.getWriter();
+            writer.write(json);
+            writer.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/prgrms/artzip/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/artzip/common/jwt/JwtAuthenticationFilter.java
@@ -49,7 +49,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       FilterChain chain) throws ServletException, IOException {
     if (SecurityContextHolder.getContext().getAuthentication() == null) {
       String token = getAccessToken(request);
+      log.info("filter enter");
       if (nonNull(token)) {
+        log.info("token is not null : {}", token);
         try {
           AccessClaim claims = jwtService.verifyAccessToken(token);
           Long userId = claims.getUserId();

--- a/src/main/java/com/prgrms/artzip/user/controller/MyController.java
+++ b/src/main/java/com/prgrms/artzip/user/controller/MyController.java
@@ -1,69 +1,17 @@
 package com.prgrms.artzip.user.controller;
 
-import com.prgrms.artzip.comment.service.CommentService;
-import com.prgrms.artzip.common.ApiResponse;
-import com.prgrms.artzip.common.entity.CurrentUser;
-import com.prgrms.artzip.exibition.service.ExhibitionLikeService;
-import com.prgrms.artzip.exibition.service.ExhibitionService;
-import com.prgrms.artzip.review.service.ReviewLikeService;
-import com.prgrms.artzip.review.service.ReviewService;
-import com.prgrms.artzip.user.domain.User;
-import com.prgrms.artzip.user.dto.response.UserResponse;
-import com.prgrms.artzip.user.service.UserService;
 import io.swagger.annotations.Api;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import static org.springframework.http.HttpStatus.*;
 
 @Api(tags = {"users-me"})
 @RestController
 @RequestMapping("api/v1/users/me")
+@RequiredArgsConstructor
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class MyController {
-    private Logger log = LoggerFactory.getLogger(getClass());
-    private final UserService userService;
 
-    private final ReviewService reviewService;
-
-    private final CommentService commentService;
-
-    private final ExhibitionService exhibitionService;
-
-    private final ExhibitionLikeService exhibitionLikeService;
-
-    private final ReviewLikeService reviewLikeService;
-
-    public MyController(UserService userService, ReviewService reviewService, CommentService commentService, ExhibitionService exhibitionService, ExhibitionLikeService exhibitionLikeService, ReviewLikeService reviewLikeService) {
-        this.userService = userService;
-        this.reviewService = reviewService;
-        this.commentService = commentService;
-        this.exhibitionService = exhibitionService;
-        this.exhibitionLikeService = exhibitionLikeService;
-        this.reviewLikeService = reviewLikeService;
-    }
-
-    @GetMapping("/info")
-    public ResponseEntity<ApiResponse<UserResponse>> getUserInfo (@CurrentUser User user) {
-        UserResponse userResponse = UserResponse.builder()
-                .userId(user.getId())
-                .nickname(user.getNickname())
-                .profileImage(user.getProfileImage())
-                .email(user.getEmail())
-                .reviewCount(reviewService.getReviewCountByUserId(user.getId()))
-                .exhibitionLikeCount(exhibitionLikeService.getExhibitionLikeCountByUserId(user.getId()))
-                .reviewLikeCount(reviewLikeService.getReviewLikeCountByUserId(user.getId()))
-                .commentCount(commentService.getCommentCountByUserId(user.getId())).build();
-        ApiResponse apiResponse = ApiResponse.builder()
-                .message("유저 정보 조회 성공하였습니다.")
-                .status(OK.value())
-                .data(userResponse)
-                .build();
-        return ResponseEntity.ok(apiResponse);
-    }
 }

--- a/src/main/java/com/prgrms/artzip/user/controller/MyController.java
+++ b/src/main/java/com/prgrms/artzip/user/controller/MyController.java
@@ -14,6 +14,7 @@ import io.swagger.annotations.Api;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -48,6 +49,7 @@ public class MyController {
     }
 
     @GetMapping("/info")
+    @PreAuthorize("hasAuthority('USER')")
     public ResponseEntity<ApiResponse<UserResponse>> getUserInfo (@CurrentUser User user) {
         UserResponse userResponse = UserResponse.builder()
                 .userId(user.getId())

--- a/src/main/java/com/prgrms/artzip/user/controller/MyController.java
+++ b/src/main/java/com/prgrms/artzip/user/controller/MyController.java
@@ -49,7 +49,6 @@ public class MyController {
     }
 
     @GetMapping("/info")
-    @PreAuthorize("hasAuthority('USER')")
     public ResponseEntity<ApiResponse<UserResponse>> getUserInfo (@CurrentUser User user) {
         UserResponse userResponse = UserResponse.builder()
                 .userId(user.getId())

--- a/src/main/java/com/prgrms/artzip/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/artzip/user/controller/UserController.java
@@ -61,7 +61,7 @@ public class UserController {
     return ResponseEntity.ok(response);
   }
 
-  @PostMapping("/sign-up")
+  @PostMapping("/signup")
   public ResponseEntity<ApiResponse<SignUpResponse>> signUp(@RequestBody @Valid
                                                             UserSignUpRequest request) {
     User newUser = userService.signUp(request);
@@ -70,6 +70,6 @@ public class UserController {
             .status(CREATED.value())
             .data(SignUpResponse.from(newUser))
             .build();
-    return ResponseEntity.created(URI.create("/register")).body(response);
+    return ResponseEntity.created(URI.create("/signup")).body(response);
   }
 }

--- a/src/main/java/com/prgrms/artzip/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/artzip/user/controller/UserController.java
@@ -6,9 +6,9 @@ import com.prgrms.artzip.common.jwt.JwtPrincipal;
 import com.prgrms.artzip.common.util.JwtService;
 import com.prgrms.artzip.user.domain.User;
 import com.prgrms.artzip.user.dto.request.UserLocalLoginRequest;
-import com.prgrms.artzip.user.dto.request.UserRegisterRequest;
+import com.prgrms.artzip.user.dto.request.UserSignUpRequest;
 import com.prgrms.artzip.user.dto.response.LoginResponse;
-import com.prgrms.artzip.user.dto.response.RegisterResponse;
+import com.prgrms.artzip.user.dto.response.SignUpResponse;
 import com.prgrms.artzip.user.service.UserService;
 import io.swagger.annotations.Api;
 import org.springframework.http.ResponseEntity;
@@ -61,14 +61,14 @@ public class UserController {
     return ResponseEntity.ok(response);
   }
 
-  @PostMapping("/register")
-  public ResponseEntity<ApiResponse<RegisterResponse>> register(@RequestBody @Valid
-      UserRegisterRequest request) {
-    User newUser = userService.register(request);
+  @PostMapping("/sign-up")
+  public ResponseEntity<ApiResponse<SignUpResponse>> signUp(@RequestBody @Valid
+                                                            UserSignUpRequest request) {
+    User newUser = userService.signUp(request);
     ApiResponse response = ApiResponse.builder()
             .message("회원가입 성공하였습니다.")
             .status(CREATED.value())
-            .data(RegisterResponse.from(newUser))
+            .data(SignUpResponse.from(newUser))
             .build();
     return ResponseEntity.created(URI.create("/register")).body(response);
   }

--- a/src/main/java/com/prgrms/artzip/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/artzip/user/controller/UserController.java
@@ -1,16 +1,26 @@
 package com.prgrms.artzip.user.controller;
 
+import com.prgrms.artzip.comment.service.CommentService;
 import com.prgrms.artzip.common.ApiResponse;
+import com.prgrms.artzip.common.entity.CurrentUser;
 import com.prgrms.artzip.common.jwt.JwtAuthenticationToken;
 import com.prgrms.artzip.common.jwt.JwtPrincipal;
 import com.prgrms.artzip.common.util.JwtService;
+import com.prgrms.artzip.exibition.service.ExhibitionLikeService;
+import com.prgrms.artzip.exibition.service.ExhibitionService;
+import com.prgrms.artzip.review.service.ReviewLikeService;
+import com.prgrms.artzip.review.service.ReviewService;
 import com.prgrms.artzip.user.domain.User;
+import com.prgrms.artzip.user.domain.repository.UserRepository;
 import com.prgrms.artzip.user.dto.request.UserLocalLoginRequest;
 import com.prgrms.artzip.user.dto.request.UserSignUpRequest;
 import com.prgrms.artzip.user.dto.response.LoginResponse;
 import com.prgrms.artzip.user.dto.response.SignUpResponse;
+import com.prgrms.artzip.user.dto.response.UserResponse;
 import com.prgrms.artzip.user.service.UserService;
+import com.prgrms.artzip.user.service.UserUtilService;
 import io.swagger.annotations.Api;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
@@ -25,22 +35,26 @@ import static org.springframework.http.HttpStatus.*;
 @Api(tags = {"users"})
 @RestController
 @RequestMapping("api/v1/users")
+@RequiredArgsConstructor
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class UserController {
 
   private final UserService userService;
 
+  private final UserUtilService userUtilService;
+
   private final JwtService jwtService;
 
   private final AuthenticationManager authenticationManager;
 
-  public UserController(UserService userService,
-                        JwtService jwtService,
-                        AuthenticationManager authenticationManager) {
-    this.userService = userService;
-    this.jwtService = jwtService;
-    this.authenticationManager = authenticationManager;
-  }
+  private final ReviewService reviewService;
+
+  private final CommentService commentService;
+
+  private final ExhibitionLikeService exhibitionLikeService;
+
+  private final ReviewLikeService reviewLikeService;
+
 
   @PostMapping("/local/login")
   public ResponseEntity<ApiResponse<LoginResponse>> localLogin(@RequestBody @Valid UserLocalLoginRequest request) {
@@ -71,5 +85,25 @@ public class UserController {
             .data(SignUpResponse.from(newUser))
             .build();
     return ResponseEntity.created(URI.create("/signup")).body(response);
+  }
+
+  @GetMapping("/{userId}/info")
+  public ResponseEntity<ApiResponse<UserRepository>> getUserInfo (@PathVariable("userId") Long userId) {
+    User user = userUtilService.getUserById(userId);
+    UserResponse userResponse = UserResponse.builder()
+            .userId(user.getId())
+            .nickname(user.getNickname())
+            .profileImage(user.getProfileImage())
+            .email(user.getEmail())
+            .reviewCount(reviewService.getReviewCountByUserId(user.getId()))
+            .exhibitionLikeCount(exhibitionLikeService.getExhibitionLikeCountByUserId(user.getId()))
+            .reviewLikeCount(reviewLikeService.getReviewLikeCountByUserId(user.getId()))
+            .commentCount(commentService.getCommentCountByUserId(user.getId())).build();
+    ApiResponse apiResponse = ApiResponse.builder()
+            .message("유저 정보 조회 성공하였습니다.")
+            .status(OK.value())
+            .data(userResponse)
+            .build();
+    return ResponseEntity.ok(apiResponse);
   }
 }

--- a/src/main/java/com/prgrms/artzip/user/dto/request/UserLocalLoginRequest.java
+++ b/src/main/java/com/prgrms/artzip/user/dto/request/UserLocalLoginRequest.java
@@ -1,16 +1,19 @@
 package com.prgrms.artzip.user.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserLocalLoginRequest {
   @NotBlank
-  private final String email;
+  private String email;
 
   @NotBlank
-  private final String password;
+  private String password;
 }

--- a/src/main/java/com/prgrms/artzip/user/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/prgrms/artzip/user/dto/request/UserSignUpRequest.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.NotBlank;
 
 @Getter
 @Builder
-public class UserRegisterRequest {
+public class UserSignUpRequest {
 
   @NotBlank
   private final String email;

--- a/src/main/java/com/prgrms/artzip/user/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/prgrms/artzip/user/dto/request/UserSignUpRequest.java
@@ -1,9 +1,6 @@
 package com.prgrms.artzip.user.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 

--- a/src/main/java/com/prgrms/artzip/user/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/prgrms/artzip/user/dto/request/UserSignUpRequest.java
@@ -1,20 +1,24 @@
 package com.prgrms.artzip.user.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class UserSignUpRequest {
 
   @NotBlank
-  private final String email;
+  private String email;
 
   @NotBlank
-  private final String nickname;
+  private String nickname;
 
   @NotBlank
-  private final String password;
+  private String password;
 }

--- a/src/main/java/com/prgrms/artzip/user/dto/response/SignUpResponse.java
+++ b/src/main/java/com/prgrms/artzip/user/dto/response/SignUpResponse.java
@@ -6,15 +6,15 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class RegisterResponse {
+public class SignUpResponse {
   private final Long userId;
 
   private final String email;
 
   private final String nickname;
 
-  public static RegisterResponse from(User user) {
-    return RegisterResponse.builder()
+  public static SignUpResponse from(User user) {
+    return SignUpResponse.builder()
         .userId(user.getId())
         .email(user.getEmail())
         .nickname(user.getNickname())

--- a/src/main/java/com/prgrms/artzip/user/service/UserService.java
+++ b/src/main/java/com/prgrms/artzip/user/service/UserService.java
@@ -12,7 +12,7 @@ import com.prgrms.artzip.user.domain.Role;
 import com.prgrms.artzip.user.domain.User;
 import com.prgrms.artzip.user.domain.repository.RoleRepository;
 import com.prgrms.artzip.user.domain.repository.UserRepository;
-import com.prgrms.artzip.user.dto.request.UserRegisterRequest;
+import com.prgrms.artzip.user.dto.request.UserSignUpRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -39,7 +39,7 @@ public class UserService {
     }
 
     @Transactional
-    public User register(UserRegisterRequest request) {
+    public User signUp(UserSignUpRequest request) {
         if (userRepository.existsByEmailAndIsQuit(request.getEmail(), false))
             throw new AlreadyExistsException(USER_ALREADY_EXISTS);
         if (userRepository.existsByNicknameAndIsQuit(request.getNickname(), false))

--- a/src/test/java/com/prgrms/artzip/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/artzip/user/service/UserServiceTest.java
@@ -14,7 +14,7 @@ import com.prgrms.artzip.user.domain.User;
 import com.prgrms.artzip.user.domain.repository.RoleRepository;
 import com.prgrms.artzip.user.domain.repository.UserRepository;
 import com.prgrms.artzip.user.dto.request.UserLocalLoginRequest;
-import com.prgrms.artzip.user.dto.request.UserRegisterRequest;
+import com.prgrms.artzip.user.dto.request.UserSignUpRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -68,19 +68,19 @@ class UserServiceTest {
 
     @Test
     @DisplayName("정상 회원가입 테스트")
-    void testRegister() {
-        UserRegisterRequest registerRequest = UserRegisterRequest.builder()
+    void testSignUp() {
+        UserSignUpRequest signUpRequest = UserSignUpRequest.builder()
                 .email(newUser.getEmail())
                 .nickname(newUser.getNickname())
                 .password(testPassword).build();
         // given
-        when(userRepository.existsByEmailAndIsQuit(registerRequest.getEmail(), false)).thenReturn(false);
-        when(userRepository.existsByNicknameAndIsQuit(registerRequest.getNickname(), false)).thenReturn(false);
+        when(userRepository.existsByEmailAndIsQuit(signUpRequest.getEmail(), false)).thenReturn(false);
+        when(userRepository.existsByNicknameAndIsQuit(signUpRequest.getNickname(), false)).thenReturn(false);
         when(roleRepository.findByAuthority(Authority.USER)).thenReturn(Optional.of(userRole));
         when(userRepository.save(any())).thenReturn(newUser);
 
         //when
-        User userResult = userService.register(registerRequest);
+        User userResult = userService.signUp(signUpRequest);
 
         //then
         assertThat(userResult.getEmail()).isEqualTo(newUser.getEmail());
@@ -92,30 +92,30 @@ class UserServiceTest {
 
     @Test
     @DisplayName("회원가입 시 이메일이 이미 존재하는 경우 테스트")
-    void testEmailExistRegister() {
-        UserRegisterRequest registerRequest = UserRegisterRequest.builder()
+    void testEmailExistSignUp() {
+        UserSignUpRequest signUpRequest = UserSignUpRequest.builder()
                 .email(newUser.getEmail())
                 .nickname(newUser.getNickname())
                 .password(testPassword).build();
         // given
-        when(userRepository.existsByEmailAndIsQuit(registerRequest.getEmail(), false)).thenReturn(true);
+        when(userRepository.existsByEmailAndIsQuit(signUpRequest.getEmail(), false)).thenReturn(true);
 
-        assertThatThrownBy(() -> userService.register(registerRequest))
+        assertThatThrownBy(() -> userService.signUp(signUpRequest))
                 .isInstanceOf(AlreadyExistsException.class)
                 .hasMessage(USER_ALREADY_EXISTS.getMessage());
     }
 
     @Test
     @DisplayName("회원가입 시 닉네임이 이미 존재하는 경우 테스트")
-    void testNicknameExistRegister() {
-        UserRegisterRequest registerRequest = UserRegisterRequest.builder()
+    void testNicknameExistSignUp() {
+        UserSignUpRequest signUpRequest = UserSignUpRequest.builder()
                 .email(newUser.getEmail())
                 .nickname(newUser.getNickname())
                 .password(testPassword).build();
         // given
-        when(userRepository.existsByNicknameAndIsQuit(registerRequest.getNickname(), false)).thenReturn(true);
+        when(userRepository.existsByNicknameAndIsQuit(signUpRequest.getNickname(), false)).thenReturn(true);
 
-        assertThatThrownBy(() -> userService.register(registerRequest))
+        assertThatThrownBy(() -> userService.signUp(signUpRequest))
                 .isInstanceOf(AlreadyExistsException.class)
                 .hasMessage(USER_ALREADY_EXISTS.getMessage());
     }
@@ -167,15 +167,15 @@ class UserServiceTest {
 
     @Test
     @DisplayName("회원가입 시 user role 에러 테스트")
-    void testAuthorityRegister() {
+    void testAuthoritySignUp() {
         //given
-        UserRegisterRequest registerRequest = UserRegisterRequest.builder()
+        UserSignUpRequest signUpRequest = UserSignUpRequest.builder()
                 .email(newUser.getEmail())
                 .nickname(newUser.getNickname())
                 .password(testPassword).build();
         when(roleRepository.findByAuthority(Authority.USER)).thenReturn(Optional.empty());
         //when then
-        assertThatThrownBy(() -> userService.register(registerRequest))
+        assertThatThrownBy(() -> userService.signUp(signUpRequest))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ROLE_NOT_FOUND.getMessage());
     }


### PR DESCRIPTION
## Filter에서 예외 발생 시 예외 처리 구현, 유저 정보 조회 API 구현
### ExceptionHandlerFilter 구현
* Spring Security에서 accessDeniedHandler와 authenticationEntryPoint를 구현하여 403 forbidden과 401 unauthorized를 처리할 수 있도록 했습니다.
* Filter는 DispatcherServlet보다 앞단에 위치하고 있기 때문에 GlobalExceptionHandler로 예외를 처리해줄 수 없습니다. 그래서 ExceptionHandlerFilter를 구현하여 커스텀 예외를 처리할 수 있도록 했습니다.
### 유저 정보 조회 API 구현
* 공공과 상의하여 조회하는 API는 하나로 합치기로 했습니다. 내 정보 조회 -> 유저 정보 조회를 이용하기로 결정했습니다.
* 따라서 내 정보 조회 API는 제거하였습니다.
### DTO NoArgsConstructor 추가
* Exception 처리를 하면서 ObjectMapper를 따로 정의한 이후부터인 것으로 추측이 되는데, 저도 dto에 기본 생성자가 없으면 에러가 발생합니다.. 이에 dto에 NoArgsConstructor를 추가하였습니다.
### 회원가입 url 변경
* 멘토님의 조언에 따라 register -> signup으로 변경
    * register: 일회성 사용자 정보 등록
    * signup: 회원가입 느낌이 더 강하다고 함