### PR TITLE
후기 삭제 구현

### DIFF
--- a/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -126,6 +127,12 @@ public class WebSecurityConfig {
                         "/api/v1/comments/**",
                         "/api/v1/reviews/**/comments/new",
                         "/api/v1/exhibitions/**/likes").hasAnyAuthority(USER.name(), ADMIN.name())
+                .antMatchers(HttpMethod.POST,
+                    "/api/v1/reviews").hasAnyAuthority(USER.name(), ADMIN.name())
+                .antMatchers(HttpMethod.PATCH,
+                    "/api/v1/reviews/**", "/api/v1/reviews/**/like").hasAnyAuthority(USER.name(), ADMIN.name())
+                .antMatchers(HttpMethod.DELETE,
+                    "/api/v1/reviews/**").hasAnyAuthority(USER.name(), ADMIN.name())
                 .anyRequest().permitAll()
                 .and()
                 .exceptionHandling()

--- a/src/main/java/com/prgrms/artzip/review/controller/ReviewController.java
+++ b/src/main/java/com/prgrms/artzip/review/controller/ReviewController.java
@@ -162,9 +162,11 @@ public class ReviewController {
             .build());
   }
 
+  @ApiOperation(value = "후기 삭제", notes = "후기 삭제를 요청합니다.")
   @DeleteMapping("/{reviewId}")
   public ResponseEntity<ApiResponse<ReviewIdResponse>> removeReview(
       @CurrentUser User user,
+      @ApiParam(value = "삭제할 후기의 ID")
       @PathVariable(value = "reviewId") Long reviewId) {
 
     ReviewIdResponse response = reviewService.removeReview(user, reviewId);

--- a/src/main/java/com/prgrms/artzip/review/controller/ReviewController.java
+++ b/src/main/java/com/prgrms/artzip/review/controller/ReviewController.java
@@ -29,6 +29,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -156,6 +157,21 @@ public class ReviewController {
     return ResponseEntity.ok()
         .body(ApiResponse.builder()
             .message("후기 수정 성공")
+            .status(HttpStatus.OK.value())
+            .data(response)
+            .build());
+  }
+
+  @DeleteMapping("/{reviewId}")
+  public ResponseEntity<ApiResponse<ReviewIdResponse>> removeReview(
+      @CurrentUser User user,
+      @PathVariable(value = "reviewId") Long reviewId) {
+
+    ReviewIdResponse response = reviewService.removeReview(user, reviewId);
+
+    return ResponseEntity.ok()
+        .body(ApiResponse.<ReviewIdResponse>builder()
+            .message("후기 삭제 성공")
             .status(HttpStatus.OK.value())
             .data(response)
             .build());

--- a/src/main/java/com/prgrms/artzip/review/domain/Review.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/Review.java
@@ -55,6 +55,9 @@ public class Review extends BaseEntity {
   @Column(name = "is_public", nullable = false)
   private Boolean isPublic;
 
+  @Column(name = "is_deleted", nullable = false)
+  private Boolean isDeleted;
+
   @OneToMany(mappedBy = "review")
   private List<ReviewLike> reviewLikes = new ArrayList<>();
 
@@ -71,6 +74,7 @@ public class Review extends BaseEntity {
     this.title = title;
     this.date = date;
     this.isPublic = isPublic;
+    this.isDeleted = false;
   }
 
   private void validateFields(User user, Exhibition exhibition, String content, String title,
@@ -128,6 +132,12 @@ public class Review extends BaseEntity {
     }
   }
 
+  private void validateIsDeleted(Boolean isDeleted) {
+    if (Objects.isNull(isDeleted)) {
+      throw new InvalidRequestException(ErrorCode.REVIEW_FIELD_CONTAINS_NULL_VALUE);
+    }
+  }
+
   public void updateContent(String content) {
     validateContent(content);
     this.content = content;
@@ -146,5 +156,10 @@ public class Review extends BaseEntity {
   public void updateIsPublic(Boolean isPublic) {
     validateIsPublic(isPublic);
     this.isPublic = isPublic;
+  }
+
+  public void updateIdDeleted(Boolean isDeleted) {
+    validateIsDeleted(isDeleted);
+    this.isDeleted = isDeleted;
   }
 }

--- a/src/main/java/com/prgrms/artzip/review/service/ReviewService.java
+++ b/src/main/java/com/prgrms/artzip/review/service/ReviewService.java
@@ -9,7 +9,9 @@ import com.prgrms.artzip.common.util.AmazonS3Uploader;
 import com.prgrms.artzip.exibition.domain.Exhibition;
 import com.prgrms.artzip.exibition.domain.repository.ExhibitionRepository;
 import com.prgrms.artzip.review.domain.Review;
+import com.prgrms.artzip.review.domain.ReviewLike;
 import com.prgrms.artzip.review.domain.ReviewPhoto;
+import com.prgrms.artzip.review.domain.repository.ReviewLikeRepository;
 import com.prgrms.artzip.review.domain.repository.ReviewPhotoRepository;
 import com.prgrms.artzip.review.domain.repository.ReviewRepository;
 import com.prgrms.artzip.review.dto.request.ReviewCreateRequest;
@@ -35,6 +37,7 @@ public class ReviewService {
 
   private final ReviewRepository reviewRepository;
   private final ReviewPhotoRepository reviewPhotoRepository;
+  private final ReviewLikeRepository reviewLikeRepository;
   private final UserRepository userRepository;
   private final ExhibitionRepository exhibitionRepository;
   private final AmazonS3Uploader amazonS3Uploader;
@@ -102,8 +105,13 @@ public class ReviewService {
 
     review.updateIdDeleted(true);
     removeReviewPhotos(review.getReviewPhotos());
+    removeReviewLikes(review.getReviewLikes());
 
     return new ReviewIdResponse(review.getId());
+  }
+
+  private void removeReviewLikes(List<ReviewLike> reviewLikes) {
+    reviewLikeRepository.deleteAllInBatch(reviewLikes);
   }
 
   private void removeReviewPhotosById(List<Long> reviewPhotoIds) {

--- a/src/test/java/com/prgrms/artzip/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/prgrms/artzip/review/service/ReviewServiceTest.java
@@ -3,7 +3,11 @@ package com.prgrms.artzip.review.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.prgrms.artzip.common.Authority;
 import com.prgrms.artzip.common.ErrorCode;
@@ -17,7 +21,10 @@ import com.prgrms.artzip.exibition.domain.enumType.Area;
 import com.prgrms.artzip.exibition.domain.enumType.Genre;
 import com.prgrms.artzip.exibition.domain.repository.ExhibitionRepository;
 import com.prgrms.artzip.review.domain.Review;
+import com.prgrms.artzip.review.domain.ReviewLike;
+import com.prgrms.artzip.review.domain.ReviewLikeId;
 import com.prgrms.artzip.review.domain.ReviewPhoto;
+import com.prgrms.artzip.review.domain.repository.ReviewLikeRepository;
 import com.prgrms.artzip.review.domain.repository.ReviewPhotoRepository;
 import com.prgrms.artzip.review.domain.repository.ReviewRepository;
 import com.prgrms.artzip.review.dto.request.ReviewCreateRequest;
@@ -26,13 +33,11 @@ import com.prgrms.artzip.review.dto.response.ReviewIdResponse;
 import com.prgrms.artzip.user.domain.Role;
 import com.prgrms.artzip.user.domain.User;
 import com.prgrms.artzip.user.domain.repository.UserRepository;
-
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -56,6 +61,9 @@ class ReviewServiceTest {
 
     @Mock
     private ReviewPhotoRepository reviewPhotoRepository;
+
+    @Mock
+    private ReviewLikeRepository reviewLikeRepository;
 
     @Mock
     private UserRepository userRepository;
@@ -591,7 +599,7 @@ class ReviewServiceTest {
     class Success {
 
       @Test
-      @DisplayName("후기 삭제 정상 작동")
+      @DisplayName("후기에 reviewPhoto가 없는 경우 후기 삭제 정상 작동")
       void testReviewSoftDeletion() {
         // given
         doReturn(Optional.of(review)).when(reviewRepository).findById(review.getId());
@@ -600,6 +608,30 @@ class ReviewServiceTest {
         ReviewIdResponse response = reviewService.removeReview(user, review.getId());
 
         // then
+        assertThat(response.getReviewId()).isEqualTo(review.getId());
+        Optional<Review> maybeReview = reviewRepository.findById(response.getReviewId());
+        assertThat(maybeReview.isPresent()).isTrue();
+        assertThat(maybeReview.get().getIsDeleted()).isEqualTo(true);
+      }
+
+      @Test
+      @DisplayName("후기에 reviewPhoto가 있는 경우 후기 삭제 정상 작동")
+      void testReviewSoftDeletionWithReviewPhoto() {
+        // given
+        int reviewPhotoCount = 4;
+        for (int i = 0; i < reviewPhotoCount; i++) {
+          new ReviewPhoto(review, "https://s3-review-photo.png");
+        }
+
+        doReturn(Optional.of(review)).when(reviewRepository).findById(review.getId());
+
+        // when
+        ReviewIdResponse response = reviewService.removeReview(user, review.getId());
+
+        // then
+        verify(amazonS3Remover, times(reviewPhotoCount)).removeFile(any(), any());
+        verify(reviewPhotoRepository, times(reviewPhotoCount)).delete(any());
+
         assertThat(response.getReviewId()).isEqualTo(review.getId());
         Optional<Review> maybeReview = reviewRepository.findById(response.getReviewId());
         assertThat(maybeReview.isPresent()).isTrue();


### PR DESCRIPTION
## 구현 내용
### 후기 삭제
- 후기 삭제 controller
- 후기 삭제 service 및 테스트
### DB 변경
- Review 테이블에 is_deleted 추가
- RDS에 적용 완료
### 기타
- soft delete
  - Review (후기)
- hard delete
  - ReviewLike (후기에 달린 좋아요)
  - ReviewPhoto (후기 사진)
 
=> 프론트와 논의한 결과 `유저가 좋아요한 후기`를 조회할 때 `삭제`되거나 `공개 -> 비공개`된 후기는 서버에서 제외하고 응답을 보내주기로 했습니다. 따라서 좋아요(ReviewLike)를 hard delete하는게 낫다고 생각해서 이렇게 구현했습니다.