### PR TITLE
내 주변 전시회 조회 구현

### DIFF
--- a/src/main/java/com/prgrms/artzip/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/artzip/common/ErrorCode.java
@@ -70,6 +70,8 @@ public enum ErrorCode {
   INVALID_EXHB_QUERY(400, "EX016", "검색어는 필수입니다.(2 <= 검색어)"),
   INVALID_EXHB_QUERY_FOR_REVIEW(400, "EX017", "검색어는 필수입니다."),
   INVALID_CUSTOM_EXHB_CONDITION(400, "EX018", "areas와 months에는 null이 포함될 수 없습니다"),
+  INVALID_COORDINATE(400, "EX019", "옳지 않은 위도 경도 정보입니다.(-90 <= 위도 <= 90, -180 <= 경도 <= 180)"),
+  INVALID_DISTANCE(400, "EX020", "거리는 0 이상이어야 합니다."),
 
   /**
    * Comment Domain

--- a/src/main/java/com/prgrms/artzip/exhibition/controller/ExhibitionController.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/controller/ExhibitionController.java
@@ -9,6 +9,7 @@ import com.prgrms.artzip.exhibition.dto.request.ExhibitionCustomConditionRequest
 import com.prgrms.artzip.exhibition.dto.response.ExhibitionDetailInfoResponse;
 import com.prgrms.artzip.exhibition.dto.response.ExhibitionInfoResponse;
 import com.prgrms.artzip.exhibition.dto.response.ExhibitionLikeResponse;
+import com.prgrms.artzip.exhibition.dto.response.ExhibitionsAroundMeResponse;
 import com.prgrms.artzip.exhibition.service.ExhibitionLikeService;
 import com.prgrms.artzip.exhibition.service.ExhibitionSearchService;
 import com.prgrms.artzip.exhibition.service.ExhibitionService;
@@ -145,6 +146,27 @@ public class ExhibitionController {
             exhibitionSearchService.getExhibitionsByCustomCondition(
                 isNull(user) ? null : user.getId(), exhibitionCustomConditionRequest, includeEnd,
                 pageable)))
+        .build();
+
+    return ResponseEntity
+        .ok()
+        .body(apiResponse);
+  }
+
+  @ApiOperation(value = "내 주변 전시회 조회", notes = "내 주변에 있는 전시회를 조회합니다.")
+  @GetMapping("/aroundme")
+  public ResponseEntity<ApiResponse<ExhibitionsAroundMeResponse>> getExhibitionsAroundMe(
+      @CurrentUser User user,
+      @RequestParam(value = "lat", required = false, defaultValue = "37.492001") double latitude,
+      @RequestParam(value = "lng", required = false, defaultValue = "127.029704") double longitude,
+      @RequestParam(value = "dist", required = false, defaultValue = "3") double distance
+  ) {
+    ApiResponse apiResponse = ApiResponse.builder()
+        .message("내 주변의 전시회 조회 성공")
+        .status(HttpStatus.OK.value())
+        .data(new ExhibitionsAroundMeResponse(
+            exhibitionService.getExhibitionsAroundMe(isNull(user) ? null : user.getId(), latitude,
+                longitude, distance)))
         .build();
 
     return ResponseEntity

--- a/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionCustomRepository.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionCustomRepository.java
@@ -4,6 +4,7 @@ import com.prgrms.artzip.exhibition.dto.ExhibitionCustomCondition;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionBasicForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionDetailForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionForSimpleQuery;
+import com.prgrms.artzip.exhibition.dto.projection.ExhibitionWithLocationForSimpleQuery;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -28,4 +29,7 @@ public interface ExhibitionCustomRepository {
 
   Page<ExhibitionForSimpleQuery> findExhibitionsByCustomCondition(Long userId,
       ExhibitionCustomCondition exhibitionCustomCondition, Pageable pageable);
+
+  List<ExhibitionWithLocationForSimpleQuery> findExhibitionAroundMe(Long userId, double latitude,
+      double longitude, double distance);
 }

--- a/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionCustomRepository.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionCustomRepository.java
@@ -31,7 +31,7 @@ public interface ExhibitionCustomRepository {
   Page<ExhibitionForSimpleQuery> findExhibitionsByCustomCondition(Long userId,
       ExhibitionCustomCondition exhibitionCustomCondition, Pageable pageable);
 
-  List<ExhibitionWithLocationForSimpleQuery> findExhibitionAroundMe(Long userId, double latitude,
+  List<ExhibitionWithLocationForSimpleQuery> findExhibitionsAroundMe(Long userId, double latitude,
       double longitude, double distance);
 
   Optional<ReviewExhibitionInfo> findExhibitionForReview(Long userId, Long exhibitionId);

--- a/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryImpl.java
@@ -157,7 +157,6 @@ public class ExhibitionRepositoryImpl implements ExhibitionCustomRepository {
                     .otherwise(false).as("isLiked"),
                 exhibition.period,
                 exhibitionLikeForLikeCount.id.countDistinct().as("likeCount"),
-                exhibitionLikeForLikeCount.id.countDistinct().as("likeCount"),
                 review.id.countDistinct().as("reviewCount")
             )
         )

--- a/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryImpl.java
@@ -217,6 +217,10 @@ public class ExhibitionRepositoryImpl implements ExhibitionCustomRepository {
                 exhibition.id,
                 exhibition.name,
                 exhibition.thumbnail,
+                new CaseBuilder()
+                    .when(exhibitionLikeForIsLikedUserIdEq(userId))
+                    .then(true)
+                    .otherwise(false).as("isLiked"),
                 exhibition.period,
                 exhibitionLikeForLikeCount.id.countDistinct().as("likeCount"),
                 review.id.countDistinct().as("reviewCount"),

--- a/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryImpl.java
@@ -2,6 +2,10 @@ package com.prgrms.artzip.exhibition.domain.repository;
 
 import static com.prgrms.artzip.exhibition.domain.QExhibition.exhibition;
 import static com.prgrms.artzip.review.domain.QReview.review;
+import static com.querydsl.core.types.dsl.MathExpressions.acos;
+import static com.querydsl.core.types.dsl.MathExpressions.cos;
+import static com.querydsl.core.types.dsl.MathExpressions.radians;
+import static com.querydsl.core.types.dsl.MathExpressions.sin;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
@@ -12,6 +16,7 @@ import com.prgrms.artzip.exhibition.dto.ExhibitionCustomCondition;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionBasicForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionDetailForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionForSimpleQuery;
+import com.prgrms.artzip.exhibition.dto.projection.ExhibitionWithLocationForSimpleQuery;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -19,6 +24,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
@@ -199,6 +205,39 @@ public class ExhibitionRepositoryImpl implements ExhibitionCustomRepository {
     return PageableExecutionUtils.getPage(exhibitions, pageable, countQuery::fetchOne);
   }
 
+  @Override
+  public List<ExhibitionWithLocationForSimpleQuery> findExhibitionAroundMe(Long userId,
+      double latitude, double longitude, double distance) {
+    BooleanBuilder aroundMeCondition = getAroundMeCondition(latitude, longitude, distance);
+    
+    return queryFactory
+        .select(Projections.fields(ExhibitionWithLocationForSimpleQuery.class,
+                exhibition.id,
+                exhibition.name,
+                exhibition.thumbnail,
+                new CaseBuilder()
+                    .when(exhibitionLikeForIsLikedUserIdEq(userId))
+                    .then(true)
+                    .otherwise(false).as("isLiked"),
+                exhibition.period,
+                exhibitionLikeForLikeCount.id.countDistinct().as("likeCount"),
+                review.id.countDistinct().as("reviewCount"),
+                exhibition.location
+            )
+        )
+        .from(exhibition)
+        .where(aroundMeCondition)
+        .leftJoin(exhibitionLikeForIsLiked)
+        .on(exhibitionLikeForIsLiked.exhibition.eq(exhibition),
+            exhibitionLikeForIsLikedUserIdEq(userId))
+        .leftJoin(exhibitionLikeForLikeCount)
+        .on(exhibitionLikeForLikeCount.exhibition.eq(exhibition))
+        .leftJoin(review)
+        .on(review.exhibition.eq(exhibition), review.isDeleted.isFalse())
+        .groupBy(exhibition.id)
+        .fetch();
+  }
+
   private List<ExhibitionForSimpleQuery> findExhibitions(Long userId, BooleanBuilder condition,
       List<OrderSpecifier> orders, Pageable pageable) {
     return queryFactory
@@ -309,6 +348,25 @@ public class ExhibitionRepositoryImpl implements ExhibitionCustomRepository {
         .and(!exhibitionCustomCondition.getIncludeEnd() ? exhibitionEndDateGoe() : null);
 
     return customCondition;
+  }
+
+  private BooleanBuilder getAroundMeCondition(double latitude, double longitude, double distance) {
+    BooleanBuilder aroundMeCondition = new BooleanBuilder();
+
+    NumberExpression<Double> distanceExpression = acos(
+        sin(radians(Expressions.constant(latitude)))
+            .multiply(sin(radians(exhibition.location.latitude)))
+            .add(cos(radians(Expressions.constant(latitude)))
+                .multiply(cos(radians(exhibition.location.latitude)))
+                .multiply(cos(radians(Expressions.constant(longitude))
+                    .subtract(radians(exhibition.location.longitude)))))
+    ).multiply(6371);
+
+    aroundMeCondition
+        .and(exhibitionEndDateGoe())
+        .and(distanceExpression.loe(distance));
+
+    return aroundMeCondition;
   }
 
   private BooleanExpression exhibitionLikeForIsLikedUserIdEq(Long userId) {

--- a/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryImpl.java
@@ -208,7 +208,7 @@ public class ExhibitionRepositoryImpl implements ExhibitionCustomRepository {
   }
 
   @Override
-  public List<ExhibitionWithLocationForSimpleQuery> findExhibitionAroundMe(Long userId,
+  public List<ExhibitionWithLocationForSimpleQuery> findExhibitionsAroundMe(Long userId,
       double latitude, double longitude, double distance) {
     BooleanBuilder aroundMeCondition = getAroundMeCondition(latitude, longitude, distance);
 

--- a/src/main/java/com/prgrms/artzip/exhibition/dto/projection/ExhibitionWithLocationForSimpleQuery.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/dto/projection/ExhibitionWithLocationForSimpleQuery.java
@@ -1,0 +1,14 @@
+package com.prgrms.artzip.exhibition.dto.projection;
+
+import com.prgrms.artzip.exhibition.domain.vo.Location;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor
+@SuperBuilder
+public class ExhibitionWithLocationForSimpleQuery extends ExhibitionForSimpleQuery {
+  
+  private Location location;
+}

--- a/src/main/java/com/prgrms/artzip/exhibition/dto/response/ExhibitionAroundMeInfoResponse.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/dto/response/ExhibitionAroundMeInfoResponse.java
@@ -1,0 +1,30 @@
+package com.prgrms.artzip.exhibition.dto.response;
+
+import com.prgrms.artzip.exhibition.dto.projection.ExhibitionForSimpleQuery;
+import com.prgrms.artzip.exhibition.dto.projection.ExhibitionWithLocationForSimpleQuery;
+import lombok.Getter;
+
+@Getter
+public class ExhibitionAroundMeInfoResponse extends ExhibitionInfoResponse {
+
+  private String placeAddr;
+  private Double lat;
+  private Double lng;
+
+  public ExhibitionAroundMeInfoResponse(
+      ExhibitionWithLocationForSimpleQuery exhibitionWithLocationForSimpleQuery) {
+    super(ExhibitionForSimpleQuery.builder()
+        .id(exhibitionWithLocationForSimpleQuery.getId())
+        .name(exhibitionWithLocationForSimpleQuery.getName())
+        .thumbnail(exhibitionWithLocationForSimpleQuery.getThumbnail())
+        .isLiked(exhibitionWithLocationForSimpleQuery.getIsLiked())
+        .period(exhibitionWithLocationForSimpleQuery.getPeriod())
+        .likeCount(exhibitionWithLocationForSimpleQuery.getLikeCount())
+        .reviewCount(exhibitionWithLocationForSimpleQuery.getReviewCount())
+        .build());
+
+    this.placeAddr = exhibitionWithLocationForSimpleQuery.getLocation().getAddress();
+    this.lat = exhibitionWithLocationForSimpleQuery.getLocation().getLatitude();
+    this.lng = exhibitionWithLocationForSimpleQuery.getLocation().getLongitude();
+  }
+}

--- a/src/main/java/com/prgrms/artzip/exhibition/dto/response/ExhibitionInfoResponse.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/dto/response/ExhibitionInfoResponse.java
@@ -1,15 +1,10 @@
 package com.prgrms.artzip.exhibition.dto.response;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionForSimpleQuery;
-import com.prgrms.artzip.exhibition.dto.projection.ExhibitionWithLocationForSimpleQuery;
 import java.time.LocalDate;
 import lombok.Getter;
 
 @Getter
-@JsonInclude(NON_NULL)
 public class ExhibitionInfoResponse extends ExhibitionBasicInfoResponse {
 
   private LocalDate startDate;
@@ -17,9 +12,6 @@ public class ExhibitionInfoResponse extends ExhibitionBasicInfoResponse {
   private Boolean isLiked;
   private long likeCount;
   private long reviewCount;
-  private String placeAddr;
-  private Double lat;
-  private Double lng;
 
   public ExhibitionInfoResponse(ExhibitionForSimpleQuery exhibitionForSimpleQuery) {
     super(exhibitionForSimpleQuery.getId(), exhibitionForSimpleQuery.getName(),
@@ -29,21 +21,5 @@ public class ExhibitionInfoResponse extends ExhibitionBasicInfoResponse {
     this.isLiked = exhibitionForSimpleQuery.getIsLiked();
     this.likeCount = exhibitionForSimpleQuery.getLikeCount();
     this.reviewCount = exhibitionForSimpleQuery.getReviewCount();
-  }
-
-  public ExhibitionInfoResponse(
-      ExhibitionWithLocationForSimpleQuery exhibitionWithLocationForSimpleQuery) {
-    super(exhibitionWithLocationForSimpleQuery.getId(),
-        exhibitionWithLocationForSimpleQuery.getName(),
-        exhibitionWithLocationForSimpleQuery.getThumbnail());
-
-    this.startDate = exhibitionWithLocationForSimpleQuery.getPeriod().getStartDate();
-    this.endDate = exhibitionWithLocationForSimpleQuery.getPeriod().getEndDate();
-    this.isLiked = exhibitionWithLocationForSimpleQuery.getIsLiked();
-    this.likeCount = exhibitionWithLocationForSimpleQuery.getLikeCount();
-    this.reviewCount = exhibitionWithLocationForSimpleQuery.getReviewCount();
-    this.placeAddr = exhibitionWithLocationForSimpleQuery.getLocation().getAddress();
-    this.lat = exhibitionWithLocationForSimpleQuery.getLocation().getLatitude();
-    this.lng = exhibitionWithLocationForSimpleQuery.getLocation().getLongitude();
   }
 }

--- a/src/main/java/com/prgrms/artzip/exhibition/dto/response/ExhibitionInfoResponse.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/dto/response/ExhibitionInfoResponse.java
@@ -4,6 +4,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionForSimpleQuery;
+import com.prgrms.artzip.exhibition.dto.projection.ExhibitionWithLocationForSimpleQuery;
 import java.time.LocalDate;
 import lombok.Getter;
 
@@ -16,6 +17,7 @@ public class ExhibitionInfoResponse extends ExhibitionBasicInfoResponse {
   private Boolean isLiked;
   private long likeCount;
   private long reviewCount;
+  private String placeAddr;
   private Double lat;
   private Double lng;
 
@@ -27,5 +29,21 @@ public class ExhibitionInfoResponse extends ExhibitionBasicInfoResponse {
     this.isLiked = exhibitionForSimpleQuery.getIsLiked();
     this.likeCount = exhibitionForSimpleQuery.getLikeCount();
     this.reviewCount = exhibitionForSimpleQuery.getReviewCount();
+  }
+
+  public ExhibitionInfoResponse(
+      ExhibitionWithLocationForSimpleQuery exhibitionWithLocationForSimpleQuery) {
+    super(exhibitionWithLocationForSimpleQuery.getId(),
+        exhibitionWithLocationForSimpleQuery.getName(),
+        exhibitionWithLocationForSimpleQuery.getThumbnail());
+
+    this.startDate = exhibitionWithLocationForSimpleQuery.getPeriod().getStartDate();
+    this.endDate = exhibitionWithLocationForSimpleQuery.getPeriod().getEndDate();
+    this.isLiked = exhibitionWithLocationForSimpleQuery.getIsLiked();
+    this.likeCount = exhibitionWithLocationForSimpleQuery.getLikeCount();
+    this.reviewCount = exhibitionWithLocationForSimpleQuery.getReviewCount();
+    this.placeAddr = exhibitionWithLocationForSimpleQuery.getLocation().getAddress();
+    this.lat = exhibitionWithLocationForSimpleQuery.getLocation().getLatitude();
+    this.lng = exhibitionWithLocationForSimpleQuery.getLocation().getLongitude();
   }
 }

--- a/src/main/java/com/prgrms/artzip/exhibition/dto/response/ExhibitionsAroundMeResponse.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/dto/response/ExhibitionsAroundMeResponse.java
@@ -1,0 +1,15 @@
+package com.prgrms.artzip.exhibition.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ExhibitionsAroundMeResponse {
+
+  private List<ExhibitionAroundMeInfoResponse> exhibitions;
+
+  public ExhibitionsAroundMeResponse(
+      List<ExhibitionAroundMeInfoResponse> exhibitions) {
+    this.exhibitions = exhibitions;
+  }
+}

--- a/src/main/java/com/prgrms/artzip/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/service/ExhibitionService.java
@@ -1,6 +1,8 @@
 package com.prgrms.artzip.exhibition.service;
 
 import static com.prgrms.artzip.common.ErrorCode.EXHB_NOT_FOUND;
+import static com.prgrms.artzip.common.ErrorCode.INVALID_COORDINATE;
+import static com.prgrms.artzip.common.ErrorCode.INVALID_DISTANCE;
 import static org.springframework.util.StringUtils.hasText;
 
 import com.prgrms.artzip.common.error.exception.InvalidRequestException;
@@ -75,14 +77,28 @@ public class ExhibitionService {
     return exhibitionsPagingResult.map(ExhibitionInfoResponse::new);
   }
 
-
   public List<ExhibitionAroundMeInfoResponse> getExhibitionsAroundMe(Long userId, double latitude,
       double longitude, double distance) {
+    validateCoordinate(latitude, longitude);
+    validateDistance(distance);
+
     List<ExhibitionWithLocationForSimpleQuery> exhibitions = exhibitionRepository.findExhibitionsAroundMe(
         userId, latitude, longitude, distance);
 
     return exhibitions.stream()
         .map(ExhibitionAroundMeInfoResponse::new)
         .collect(Collectors.toList());
+  }
+
+  private void validateCoordinate(double latitude, double longitude) {
+    if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+      throw new InvalidRequestException(INVALID_COORDINATE);
+    }
+  }
+
+  private void validateDistance(double distance) {
+    if (distance <= 0) {
+      throw new InvalidRequestException(INVALID_DISTANCE);
+    }
   }
 }

--- a/src/main/java/com/prgrms/artzip/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/service/ExhibitionService.java
@@ -8,6 +8,7 @@ import com.prgrms.artzip.exhibition.domain.repository.ExhibitionRepository;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionDetailForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionWithLocationForSimpleQuery;
+import com.prgrms.artzip.exhibition.dto.response.ExhibitionAroundMeInfoResponse;
 import com.prgrms.artzip.exhibition.dto.response.ExhibitionDetailInfoResponse;
 import com.prgrms.artzip.exhibition.dto.response.ExhibitionInfoResponse;
 import java.util.List;
@@ -75,13 +76,13 @@ public class ExhibitionService {
   }
 
 
-  public List<ExhibitionInfoResponse> getExhibitionsAroundMe(Long userId, double latitude,
+  public List<ExhibitionAroundMeInfoResponse> getExhibitionsAroundMe(Long userId, double latitude,
       double longitude, double distance) {
     List<ExhibitionWithLocationForSimpleQuery> exhibitions = exhibitionRepository.findExhibitionsAroundMe(
         userId, latitude, longitude, distance);
 
     return exhibitions.stream()
-        .map(ExhibitionInfoResponse::new)
+        .map(ExhibitionAroundMeInfoResponse::new)
         .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/prgrms/artzip/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/service/ExhibitionService.java
@@ -7,8 +7,11 @@ import com.prgrms.artzip.common.error.exception.InvalidRequestException;
 import com.prgrms.artzip.exhibition.domain.repository.ExhibitionRepository;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionDetailForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionForSimpleQuery;
+import com.prgrms.artzip.exhibition.dto.projection.ExhibitionWithLocationForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.response.ExhibitionDetailInfoResponse;
 import com.prgrms.artzip.exhibition.dto.response.ExhibitionInfoResponse;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -69,5 +72,16 @@ public class ExhibitionService {
         .findUserLikeExhibitions(userId, exhibitionLikeUserId, pageable);
 
     return exhibitionsPagingResult.map(ExhibitionInfoResponse::new);
+  }
+
+
+  public List<ExhibitionInfoResponse> getExhibitionsAroundMe(Long userId, double latitude,
+      double longitude, double distance) {
+    List<ExhibitionWithLocationForSimpleQuery> exhibitions = exhibitionRepository.findExhibitionsAroundMe(
+        userId, latitude, longitude, distance);
+
+    return exhibitions.stream()
+        .map(ExhibitionInfoResponse::new)
+        .collect(Collectors.toList());
   }
 }

--- a/src/test/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryTest.java
+++ b/src/test/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryTest.java
@@ -851,7 +851,7 @@ class ExhibitionRepositoryTest {
     @DisplayName("내 주변 전시회 3KM 조건 테스트")
     void testAroundMe3KM() {
       List<ExhibitionWithLocationForSimpleQuery> exhibitions = exhibitionRepository
-          .findExhibitionAroundMe(null, 37.492001, 127.029704, 3);
+          .findExhibitionsAroundMe(null, 37.492001, 127.029704, 3);
 
       assertThat(exhibitions).hasSize(1);
       assertThat(exhibitions.get(0))

--- a/src/test/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryTest.java
+++ b/src/test/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryTest.java
@@ -21,6 +21,7 @@ import com.prgrms.artzip.exhibition.dto.ExhibitionCustomCondition;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionBasicForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionDetailForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionForSimpleQuery;
+import com.prgrms.artzip.exhibition.dto.projection.ExhibitionWithLocationForSimpleQuery;
 import com.prgrms.artzip.review.domain.Review;
 import com.prgrms.artzip.user.domain.Role;
 import com.prgrms.artzip.user.domain.User;
@@ -772,6 +773,90 @@ class ExhibitionRepositoryTest {
       assertThat(contents.get(0))
           .hasFieldOrPropertyWithValue("name", "전시회 at 부산")
           .hasFieldOrPropertyWithValue("isLiked", true);
+    }
+  }
+
+  @Nested
+  @DisplayName("findExhibitionAroundMe() 테스트")
+  class FindExhibitionAroundMeTest {
+
+    @BeforeEach
+    void setUp() {
+      Exhibition exhibitionAtBusan = Exhibition.builder()
+          .seq(32)
+          .name("전시회 at 부산")
+          .startDate(LocalDate.now().plusDays(10))
+          .endDate(LocalDate.now().plusDays(15))
+          .genre(Genre.FINEART)
+          .description("이것은 전시회 설명입니다.")
+          .latitude(37.501086)
+          .longitude(127.053447)
+          .area(BUSAN)
+          .place("미술관")
+          .address("부산 동구 중앙대로 11")
+          .inquiry("문의처 정보")
+          .fee("성인 20,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/22/07/show_2022072010193392447.jpg")
+          .url("https://www.example.com")
+          .placeUrl("https://www.place-example.com")
+          .build();
+      em.persist(exhibitionAtBusan);
+
+      Exhibition exhibitionAtSeoul = Exhibition.builder()
+          .seq(33)
+          .name("전시회 at 서울")
+          .startDate(LocalDate.now().plusDays(20))
+          .endDate(LocalDate.now().plusDays(25))
+          .genre(Genre.FINEART)
+          .description("이것은 전시회 설명입니다.")
+          .latitude(37.564138)
+          .longitude(126.973763)
+          .area(SEOUL)
+          .place("미술관")
+          .address("서울 어딘가")
+          .inquiry("문의처 정보")
+          .fee("성인 20,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/22/07/show_2022072010193392447.jpg")
+          .url("https://www.example.com")
+          .placeUrl("https://www.place-example.com")
+          .build();
+      em.persist(exhibitionAtSeoul);
+
+      Exhibition exhibitionAtGyeonggi = Exhibition.builder()
+          .seq(34)
+          .name("전시회 at 경기")
+          .startDate(LocalDate.now().minusDays(10))
+          .endDate(LocalDate.now().minusDays(5))
+          .genre(Genre.FINEART)
+          .description("이것은 전시회 설명입니다.")
+          .latitude(37.496193)
+          .longitude(127.030906)
+          .area(GYEONGGI)
+          .place("미술관")
+          .address("경기도 성남시")
+          .inquiry("문의처 정보")
+          .fee("성인 20,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/22/07/show_2022072010193392447.jpg")
+          .url("https://www.example.com")
+          .placeUrl("https://www.place-example.com")
+          .build();
+      em.persist(exhibitionAtGyeonggi);
+
+      em.flush();
+      em.clear();
+    }
+    
+    @Test
+    @DisplayName("내 주변 전시회 3KM 조건 테스트")
+    void testAroundMe3KM() {
+      List<ExhibitionWithLocationForSimpleQuery> exhibitions = exhibitionRepository
+          .findExhibitionAroundMe(null, 37.492001, 127.029704, 3);
+
+      assertThat(exhibitions).hasSize(1);
+      assertThat(exhibitions.get(0))
+          .hasFieldOrPropertyWithValue("name", "전시회 at 부산")
+          .hasFieldOrPropertyWithValue("location.latitude", 37.501086)
+          .hasFieldOrPropertyWithValue("location.longitude", 127.053447);
     }
   }
 }

--- a/src/test/java/com/prgrms/artzip/exhibition/service/ExhibitionServiceTest.java
+++ b/src/test/java/com/prgrms/artzip/exhibition/service/ExhibitionServiceTest.java
@@ -2,6 +2,7 @@ package com.prgrms.artzip.exhibition.service;
 
 import static com.prgrms.artzip.common.ErrorCode.EXHB_NOT_FOUND;
 import static com.prgrms.artzip.exhibition.domain.enumType.Area.GYEONGGI;
+import static com.prgrms.artzip.exhibition.domain.enumType.Area.SEOUL;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -11,16 +12,17 @@ import com.prgrms.artzip.common.error.exception.InvalidRequestException;
 import com.prgrms.artzip.exhibition.domain.Exhibition;
 import com.prgrms.artzip.exhibition.domain.enumType.Area;
 import com.prgrms.artzip.exhibition.domain.enumType.Genre;
-import com.prgrms.artzip.exhibition.domain.repository.ExhibitionLikeRepository;
 import com.prgrms.artzip.exhibition.domain.repository.ExhibitionRepository;
 import com.prgrms.artzip.exhibition.domain.vo.Location;
 import com.prgrms.artzip.exhibition.domain.vo.Period;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionDetailForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionForSimpleQuery;
+import com.prgrms.artzip.exhibition.dto.projection.ExhibitionWithLocationForSimpleQuery;
 import com.prgrms.artzip.user.domain.Role;
 import com.prgrms.artzip.user.domain.User;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -40,9 +42,6 @@ class ExhibitionServiceTest {
 
   @Mock
   private ExhibitionRepository exhibitionRepository;
-
-  @Mock
-  private ExhibitionLikeRepository exhibitionLikeRepository;
 
   @InjectMocks
   private ExhibitionService exhibitionService;
@@ -234,5 +233,29 @@ class ExhibitionServiceTest {
 
     // then
     verify(exhibitionRepository).findUserLikeExhibitions(userId, exhibitionLikeUserId, pageRequest);
+  }
+
+  @Test
+  @DisplayName("사용자 주변에 있는 전시회 조회 테스트")
+  void testGetExhibitionsAroundMe() {
+    List<ExhibitionWithLocationForSimpleQuery> exhibitions = Arrays.asList(
+        ExhibitionWithLocationForSimpleQuery.builder()
+            .id(11L)
+            .name("요리조리 MOKA Garden")
+            .thumbnail("http://www.culture.go.kr/upload/rdf/22/07/show_2022071411402126915.png")
+            .isLiked(true)
+            .period(new Period(LocalDate.now().plusDays(1), LocalDate.now().plusDays(10)))
+            .likeCount(30)
+            .reviewCount(15)
+            .location(new Location(30.12, 128.12, SEOUL, "서울 어딘가 전시관", "서울특별시 마포구"))
+            .build()
+    );
+
+    when(exhibitionRepository.findExhibitionsAroundMe(null, 35.12, 128.12, 3))
+        .thenReturn(exhibitions);
+
+    exhibitionService.getExhibitionsAroundMe(null, 35.12, 128.12, 3);
+
+    verify(exhibitionRepository).findExhibitionsAroundMe(null, 35.12, 128.12, 3);
   }
 }


### PR DESCRIPTION
## 구현 내용
### 내 주변 전시회 조회
* 좌표를 기반으로 내 주변 전시회들을 조회할 수 있는 API를 개발하였습니다.
* 해당 기능에 대한 service, repository 테스트 코드를 작성하였습니다.
* conflict를 해결하다 보니 PR에 현서님이 전에 구현하신 부분들이 섞여 있습니다.
