### PR TITLE
Exhibition 엔티티 수정

### DIFF
--- a/src/main/java/com/prgrms/artzip/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/artzip/common/ErrorCode.java
@@ -51,11 +51,10 @@ public enum ErrorCode {
   /**
    * Exhibition Domain
    */
-  INVALID_EXHBN_SEQ(400, "EX001", "전시회 seq는 필수입니다."),
   INVALID_EXHBN_NAME(400, "EX002", "전시회 이름은 필수입니다.(1 <= 전시회 이름 <= 70)"),
   INVALID_EXHBN_PERIOD(400, "EX003", "전시회 기간 정보는 필수입니다.(startDate <= endDate)"),
   INVALID_EXHBN_DESCRIPTION(400, "EX004", "전시회 설명은 최대 1000자 입니다."),
-  INVALID_EXHBN_COORDINATE(400, "EX005", "전시회 좌표는 필수입니다."),
+  INVALID_EXHBN_COORDINATE(400, "EX005", "전시회 좌표는 필수입니다.(-90 <= 위도 <= 90, -180 <= 경도 <= 180)"),
   INVALID_EXHB_AREA(400, "EX006", "전시회 지역은 필수입니다."),
   INVALID_EXHB_PLACE(400, "EX007", "전시회 장소는 필수입니다.(1 <= 전시회 장소 <= 20)"),
   INVALID_EXHB_ADDRESS(400, "EX008", "전시회 상세 주소는 필수입니다.(1 <= 전시회 주소 <= 100)"),

--- a/src/main/java/com/prgrms/artzip/exhibition/domain/Exhibition.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/domain/Exhibition.java
@@ -94,6 +94,9 @@ public class Exhibition extends BaseEntity {
   @OneToMany(mappedBy = "exhibition")
   private List<Review> reviews = new ArrayList<>();
 
+  @Column(name = "is_deleted", nullable = false)
+  private Boolean isDeleted;
+
   @Builder
   public Exhibition(Integer seq, String name, LocalDate startDate, LocalDate endDate, Genre genre,
       String description, Double latitude, Double longitude, Area area, String place,
@@ -109,6 +112,11 @@ public class Exhibition extends BaseEntity {
     setThumbnail(thumbnail);
     setUrl(url);
     setPlaceUrl(placeUrl);
+    this.isDeleted = false;
+  }
+
+  public void deleteExhibition() {
+    this.isDeleted = true;
   }
 
   private void setSeq(Integer seq) {

--- a/src/main/java/com/prgrms/artzip/exhibition/domain/Exhibition.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/domain/Exhibition.java
@@ -4,7 +4,6 @@ import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHBN_COORDINATE;
 import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHBN_DESCRIPTION;
 import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHBN_NAME;
 import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHBN_PERIOD;
-import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHBN_SEQ;
 import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHB_ADDRESS;
 import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHB_AREA;
 import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHB_FEE;
@@ -101,7 +100,7 @@ public class Exhibition extends BaseEntity {
   public Exhibition(Integer seq, String name, LocalDate startDate, LocalDate endDate, Genre genre,
       String description, Double latitude, Double longitude, Area area, String place,
       String address, String inquiry, String fee, String thumbnail, String url, String placeUrl) {
-    setSeq(seq);
+    this.seq = seq;
     setName(name);
     setPeriod(startDate, endDate);
     this.genre = genre;
@@ -117,14 +116,6 @@ public class Exhibition extends BaseEntity {
 
   public void deleteExhibition() {
     this.isDeleted = true;
-  }
-
-  private void setSeq(Integer seq) {
-    if (isNull(seq)) {
-      throw new InvalidRequestException(INVALID_EXHBN_SEQ);
-    } else {
-      this.seq = seq;
-    }
   }
 
   private void setName(String name) {
@@ -153,7 +144,8 @@ public class Exhibition extends BaseEntity {
 
   private void setLocation(Double latitude, Double longitude, Area area, String place,
       String address) {
-    if (isNull(latitude) || isNull(longitude)) {
+    if (isNull(latitude) || isNull(longitude) || latitude < -90 || latitude > 90 || longitude < -180
+        || longitude > 180) {
       throw new InvalidRequestException(INVALID_EXHBN_COORDINATE);
     } else if (isNull(area)) {
       throw new InvalidRequestException(INVALID_EXHB_AREA);

--- a/src/main/java/com/prgrms/artzip/exhibition/service/ExhibitionLikeService.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/service/ExhibitionLikeService.java
@@ -32,6 +32,11 @@ public class ExhibitionLikeService {
     }, () -> {
       Exhibition exhibition = exhibitionRepository.findById(exhibitionId)
           .orElseThrow(() -> new InvalidRequestException(EXHB_NOT_FOUND));
+
+      if (exhibition.getIsDeleted()) {
+        throw new InvalidRequestException(EXHB_NOT_FOUND);
+      }
+
       exhibitionLikeRepository.save(new ExhibitionLike(user, exhibition));
     });
 

--- a/src/test/java/com/prgrms/artzip/exhibition/domain/ExhibitionLikeTest.java
+++ b/src/test/java/com/prgrms/artzip/exhibition/domain/ExhibitionLikeTest.java
@@ -21,7 +21,7 @@ class ExhibitionLikeTest {
       .name("전시회 제목")
       .startDate(LocalDate.now())
       .endDate(LocalDate.now())
-      .latitude(123.321)
+      .latitude(35.321)
       .longitude(123.123)
       .area(GYEONGGI)
       .place("전시관")

--- a/src/test/java/com/prgrms/artzip/exhibition/domain/ExhibitionTest.java
+++ b/src/test/java/com/prgrms/artzip/exhibition/domain/ExhibitionTest.java
@@ -1,17 +1,357 @@
 package com.prgrms.artzip.exhibition.domain;
 
+import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHBN_COORDINATE;
+import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHBN_DESCRIPTION;
+import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHBN_NAME;
+import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHBN_PERIOD;
+import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHB_ADDRESS;
+import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHB_AREA;
+import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHB_FEE;
+import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHB_INQUIRY;
+import static com.prgrms.artzip.common.ErrorCode.INVALID_EXHB_PLACE;
 import static com.prgrms.artzip.exhibition.domain.enumType.Area.GYEONGGI;
+import static com.prgrms.artzip.exhibition.domain.enumType.Area.SEOUL;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.prgrms.artzip.common.error.exception.InvalidRequestException;
 import java.time.LocalDate;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @DisplayName("Exhibition 엔티티 테스트")
 class ExhibitionTest {
+
+  @Nested
+  @DisplayName("name 필드 테스트")
+  class NameValidationTest {
+
+    @Test
+    @DisplayName("name이 null인 경우 테스트")
+    void testNameNull() {
+      assertThatThrownBy(() -> Exhibition.builder()
+          .seq(12345)
+          .startDate(LocalDate.now())
+          .endDate(LocalDate.now())
+          .latitude(123.321)
+          .longitude(123.123)
+          .area(GYEONGGI)
+          .place("전시관")
+          .address("경기도 용인시 수지구")
+          .inquiry("010-0000-0000")
+          .fee("1,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/21/11/show_20211181717993881.jpg")
+          .build()
+      )
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessage(INVALID_EXHBN_NAME.getMessage());
+    }
+
+    @Test
+    @DisplayName("name의 길이가 너무 긴 경우 테스트")
+    void testNameTooLong() {
+      assertThatThrownBy(() -> Exhibition.builder()
+          .seq(12345)
+          .name(
+              "이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름이름")
+          .startDate(LocalDate.now())
+          .endDate(LocalDate.now())
+          .latitude(123.321)
+          .longitude(123.123)
+          .area(GYEONGGI)
+          .place("전시관")
+          .address("경기도 용인시 수지구")
+          .inquiry("010-0000-0000")
+          .fee("1,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/21/11/show_20211181717993881.jpg")
+          .build()
+      )
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessage(INVALID_EXHBN_NAME.getMessage());
+    }
+  }
+
+  @Nested
+  @DisplayName("period 필드 테스트")
+  class PeriodValidationTest {
+
+    @Test
+    @DisplayName("startDate null인 경우 테스트")
+    void testStartDateNull() {
+      assertThatThrownBy(() -> Exhibition.builder()
+          .seq(12345)
+          .name("김이름")
+          .endDate(LocalDate.now())
+          .latitude(123.321)
+          .longitude(123.123)
+          .area(GYEONGGI)
+          .place("전시관")
+          .address("경기도 용인시 수지구")
+          .inquiry("010-0000-0000")
+          .fee("1,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/21/11/show_20211181717993881.jpg")
+          .build()
+      )
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessage(INVALID_EXHBN_PERIOD.getMessage());
+    }
+
+    @Test
+    @DisplayName("endDate null인 경우 테스트")
+    void testEndDateNull() {
+      assertThatThrownBy(() -> Exhibition.builder()
+          .seq(12345)
+          .name("김이름")
+          .startDate(LocalDate.now())
+          .latitude(123.321)
+          .longitude(123.123)
+          .area(GYEONGGI)
+          .place("전시관")
+          .address("경기도 용인시 수지구")
+          .inquiry("010-0000-0000")
+          .fee("1,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/21/11/show_20211181717993881.jpg")
+          .build()
+      )
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessage(INVALID_EXHBN_PERIOD.getMessage());
+    }
+
+    @Test
+    @DisplayName("endDate가 startDate보다 이른 경우")
+    void testStartDateIsAfter() {
+      assertThatThrownBy(() -> Exhibition.builder()
+          .seq(12345)
+          .name("김이름")
+          .startDate(LocalDate.now())
+          .endDate(LocalDate.now().minusDays(2))
+          .latitude(123.321)
+          .longitude(123.123)
+          .area(GYEONGGI)
+          .place("전시관")
+          .address("경기도 용인시 수지구")
+          .inquiry("010-0000-0000")
+          .fee("1,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/21/11/show_20211181717993881.jpg")
+          .build()
+      )
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessage(INVALID_EXHBN_PERIOD.getMessage());
+    }
+  }
+
+  @Nested
+  @DisplayName("description 필드 테스트")
+  class DescriptionValidationTest {
+
+    @Test
+    @DisplayName("description 너무 긴 경우 테스트")
+    void testDescriptionTooLong() {
+      assertThatThrownBy(() -> Exhibition.builder()
+          .seq(12345)
+          .name("이름")
+          .startDate(LocalDate.now())
+          .endDate(LocalDate.now())
+          .description(
+              "The standard Lorem Ipsum passage, used since the 1500s Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\" Section 1.10.32 of \"de Finibus Bonorum et Malorum\", written by Cicero in 45 BC \"Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?")
+          .latitude(123.321)
+          .longitude(123.123)
+          .area(GYEONGGI)
+          .place("전시관")
+          .address("경기도 용인시 수지구")
+          .inquiry("010-0000-0000")
+          .fee("1,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/21/11/show_20211181717993881.jpg")
+          .build()
+      )
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessage(INVALID_EXHBN_DESCRIPTION.getMessage());
+    }
+  }
+
+  @Nested
+  @DisplayName("location 필드 테스트")
+  class LocationValidationTest {
+
+    @Test
+    @DisplayName("잘못된 위도 테스트")
+    void testWrongLatitude() {
+      assertThatThrownBy(() -> Exhibition.builder()
+          .seq(12345)
+          .name("이름")
+          .startDate(LocalDate.now())
+          .endDate(LocalDate.now())
+          .description("설명 입니다.")
+          .latitude(-100.0)
+          .longitude(123.123)
+          .area(GYEONGGI)
+          .place("전시관")
+          .address("경기도 용인시 수지구")
+          .inquiry("010-0000-0000")
+          .fee("1,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/21/11/show_20211181717993881.jpg")
+          .build()
+      )
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessage(INVALID_EXHBN_COORDINATE.getMessage());
+    }
+
+    @Test
+    @DisplayName("잘못된 경도 테스트")
+    void testWrongLongitude() {
+      assertThatThrownBy(() -> Exhibition.builder()
+          .seq(12345)
+          .name("이름")
+          .startDate(LocalDate.now())
+          .endDate(LocalDate.now())
+          .description("설명 입니다.")
+          .latitude(35.1)
+          .longitude(-199.9)
+          .area(GYEONGGI)
+          .place("전시관")
+          .address("경기도 용인시 수지구")
+          .inquiry("010-0000-0000")
+          .fee("1,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/21/11/show_20211181717993881.jpg")
+          .build()
+      )
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessage(INVALID_EXHBN_COORDINATE.getMessage());
+    }
+
+    @Test
+    @DisplayName("area null인 경우 테스트")
+    void testAreaNull() {
+      assertThatThrownBy(() -> Exhibition.builder()
+          .seq(12345)
+          .name("이름")
+          .startDate(LocalDate.now())
+          .endDate(LocalDate.now())
+          .description("설명 입니다.")
+          .latitude(35.1)
+          .longitude(129.9)
+          .place("전시관")
+          .address("경기도 용인시 수지구")
+          .inquiry("010-0000-0000")
+          .fee("1,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/21/11/show_20211181717993881.jpg")
+          .build()
+      )
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessage(INVALID_EXHB_AREA.getMessage());
+    }
+
+    @Test
+    @DisplayName("place가 너무 긴경우 테스트")
+    void testWrongPlace() {
+      assertThatThrownBy(() -> Exhibition.builder()
+          .seq(12345)
+          .name("이름")
+          .startDate(LocalDate.now())
+          .endDate(LocalDate.now())
+          .description("설명 입니다.")
+          .latitude(35.1)
+          .longitude(129.9)
+          .area(SEOUL)
+          .place(
+              "전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관전시관")
+          .address("경기도 용인시 수지구")
+          .inquiry("010-0000-0000")
+          .fee("1,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/21/11/show_20211181717993881.jpg")
+          .build()
+      )
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessage(INVALID_EXHB_PLACE.getMessage());
+    }
+
+    @Test
+    @DisplayName("address가 너무 긴경우 테스트")
+    void testWrongAddress() {
+      assertThatThrownBy(() -> Exhibition.builder()
+          .seq(12345)
+          .name("이름")
+          .startDate(LocalDate.now())
+          .endDate(LocalDate.now())
+          .description("설명 입니다.")
+          .latitude(35.1)
+          .longitude(129.9)
+          .area(SEOUL)
+          .place("전시")
+          .address(
+              "경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 경기도 용인시 수지구 ")
+          .inquiry("010-0000-0000")
+          .fee("1,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/21/11/show_20211181717993881.jpg")
+          .build()
+      )
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessage(INVALID_EXHB_ADDRESS.getMessage());
+    }
+  }
+
+  @Nested
+  @DisplayName("inquiry 필드 테스트")
+  class InquiryValidationTest {
+
+    @Test
+    @DisplayName("inquiry가 너무 긴 경우 테스트")
+    void testWrongInquiry() {
+      assertThatThrownBy(() -> Exhibition.builder()
+          .seq(12345)
+          .name("이름")
+          .startDate(LocalDate.now())
+          .endDate(LocalDate.now())
+          .description("설명 입니다.")
+          .latitude(35.1)
+          .longitude(123.123)
+          .area(GYEONGGI)
+          .place("전시관")
+          .address("경기도 용인시 수지구")
+          .inquiry(
+              "010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000 010-0000-0000")
+          .fee("1,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/21/11/show_20211181717993881.jpg")
+          .build()
+      )
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessage(INVALID_EXHB_INQUIRY.getMessage());
+    }
+  }
+
+  @Nested
+  @DisplayName("fee 필드 테스트")
+  class FeeValidationTest {
+
+    @Test
+    @DisplayName("feer가 너무 긴 경우 테스트")
+    void testWrongFee() {
+      assertThatThrownBy(() -> Exhibition.builder()
+          .seq(12345)
+          .name("이름")
+          .startDate(LocalDate.now())
+          .endDate(LocalDate.now())
+          .description("설명 입니다.")
+          .latitude(35.1)
+          .longitude(123.123)
+          .area(GYEONGGI)
+          .place("전시관")
+          .address("경기도 용인시 수지구")
+          .inquiry("010-0000-0000")
+          .fee(
+              "1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 1,000원 ")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/21/11/show_20211181717993881.jpg")
+          .build()
+      )
+          .isInstanceOf(InvalidRequestException.class)
+          .hasMessage(INVALID_EXHB_FEE.getMessage());
+    }
+  }
 
   @DisplayName("url 검증 테스트")
   @ParameterizedTest
@@ -22,7 +362,7 @@ class ExhibitionTest {
         .name("전시회 제목")
         .startDate(LocalDate.now())
         .endDate(LocalDate.now())
-        .latitude(123.321)
+        .latitude(35.321)
         .longitude(123.123)
         .area(GYEONGGI)
         .place("전시관")

--- a/src/test/java/com/prgrms/artzip/exhibition/service/ExhibitionLikeServiceTest.java
+++ b/src/test/java/com/prgrms/artzip/exhibition/service/ExhibitionLikeServiceTest.java
@@ -85,6 +85,45 @@ class ExhibitionLikeServiceTest {
   }
 
   @Test
+  @DisplayName("삭제된 전시회에 좋아요를 추가하는 경우 테스트")
+  void testAddLikeDeletedExhibition() {
+    Exhibition deletedExhibition = Exhibition.builder()
+        .seq(32)
+        .name("전시회 제목")
+        .startDate(LocalDate.of(2022, 4, 11))
+        .endDate(LocalDate.of(2022, 6, 2))
+        .genre(Genre.FINEART)
+        .description("이것은 전시회 설명입니다.")
+        .latitude(36.22)
+        .longitude(128.02)
+        .area(Area.BUSAN)
+        .place("미술관")
+        .address("부산 동구 중앙대로 11")
+        .inquiry("문의처 정보")
+        .fee("성인 20,000원")
+        .thumbnail("https://www.image-example.com")
+        .url("https://www.example.com")
+        .placeUrl("https://www.place-example.com")
+        .build();
+    deletedExhibition.deleteExhibition();
+
+    when(exhibitionLikeRepository.findByUserIdAndExhibitionId(user.getId(), exhibitionId))
+        .thenReturn(Optional.empty());
+    when(exhibitionRepository.findById(exhibitionId)).thenReturn(Optional.of(deletedExhibition));
+
+    assertThatThrownBy(() -> exhibitionLikeService.updateExhibitionLike(user, exhibitionId))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessage(EXHB_NOT_FOUND.getMessage());
+
+    verify(exhibitionLikeRepository).findByUserIdAndExhibitionId(user.getId(), exhibitionId);
+    verify(exhibitionRepository).findById(exhibitionId);
+
+    verify(exhibitionLikeRepository, never()).delete(any());
+    verify(exhibitionLikeRepository, never()).save(any());
+    verify(exhibitionLikeRepository, never()).countByExhibitionId(exhibitionId);
+  }
+
+  @Test
   @DisplayName("좋아요 추가 테스트")
   void testAddLike() {
     when(exhibitionLikeRepository.findByUserIdAndExhibitionId(user.getId(), exhibitionId))


### PR DESCRIPTION
## 구현 내용
### Exhibition 엔티티 수정
* exhibition 엔티티에 isDeleted 필드를 추가하였습니다.
  * RDS에 해당 변경 사항을 반영하였습니다.
  * isDeleted란 필드가 추가됨에 따라 조회시 isDeleted = false인 전시회들만 조회할 수 있도록 수정하였습니다.
* deleteExhibition이라는 메서드를 클래스에 추가하였습니다.

### 테스트 코드 작성
* exhibition 엔티티 필드 검증에 대한 테스트 코드를 추가하였습니다.