### PR TITLE
전시회 상세 조회에 들어가는 reviews 구현

### DIFF
--- a/src/main/java/com/prgrms/artzip/exhibition/dto/response/ExhibitionDetailInfoResponse.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/dto/response/ExhibitionDetailInfoResponse.java
@@ -2,7 +2,9 @@ package com.prgrms.artzip.exhibition.dto.response;
 
 import com.prgrms.artzip.exhibition.domain.enumType.Area;
 import com.prgrms.artzip.exhibition.domain.enumType.Genre;
+import com.prgrms.artzip.review.dto.response.ReviewsResponseForExhibitionDetail;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
@@ -23,12 +25,12 @@ public class ExhibitionDetailInfoResponse extends ExhibitionBasicInfoResponse {
   private double lat;
   private double lng;
   private Boolean isLiked;
-  // reviews
+  private List<ReviewsResponseForExhibitionDetail> reviews;
 
   public ExhibitionDetailInfoResponse(Long exhibitionId, String name, String thumbnail,
       LocalDate startDate, LocalDate endDate, Area area, String url, String placeUrl,
       String inquiry, Genre genre, String description, long likeCount, String placeAddress,
-      double lat, double lng, boolean isLiked) {
+      double lat, double lng, boolean isLiked, List<ReviewsResponseForExhibitionDetail> reviews) {
     super(exhibitionId, name, thumbnail);
     this.startDate = startDate;
     this.endDate = endDate;
@@ -43,5 +45,6 @@ public class ExhibitionDetailInfoResponse extends ExhibitionBasicInfoResponse {
     this.lat = lat;
     this.lng = lng;
     this.isLiked = isLiked;
+    this.reviews = reviews;
   }
 }

--- a/src/main/java/com/prgrms/artzip/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/service/ExhibitionService.java
@@ -5,7 +5,9 @@ import static com.prgrms.artzip.common.ErrorCode.INVALID_COORDINATE;
 import static com.prgrms.artzip.common.ErrorCode.INVALID_DISTANCE;
 import static org.springframework.util.StringUtils.hasText;
 
+import com.prgrms.artzip.common.ErrorCode;
 import com.prgrms.artzip.common.error.exception.InvalidRequestException;
+import com.prgrms.artzip.common.error.exception.NotFoundException;
 import com.prgrms.artzip.exhibition.domain.repository.ExhibitionRepository;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionDetailForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionForSimpleQuery;
@@ -13,18 +15,29 @@ import com.prgrms.artzip.exhibition.dto.projection.ExhibitionWithLocationForSimp
 import com.prgrms.artzip.exhibition.dto.response.ExhibitionAroundMeInfoResponse;
 import com.prgrms.artzip.exhibition.dto.response.ExhibitionDetailInfoResponse;
 import com.prgrms.artzip.exhibition.dto.response.ExhibitionInfoResponse;
+import com.prgrms.artzip.review.domain.Review;
+import com.prgrms.artzip.review.domain.ReviewPhoto;
+import com.prgrms.artzip.review.domain.repository.ReviewRepository;
+import com.prgrms.artzip.review.dto.projection.ReviewWithLikeAndCommentCount;
+import com.prgrms.artzip.review.dto.response.ReviewsResponseForExhibitionDetail;
+import com.prgrms.artzip.user.domain.User;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ExhibitionService {
 
   private final ExhibitionRepository exhibitionRepository;
+  private final ReviewRepository reviewRepository;
 
   public Page<ExhibitionInfoResponse> getUpcomingExhibitions(Long userId,
       Pageable pageable) {
@@ -41,12 +54,13 @@ public class ExhibitionService {
     return exhibitionsPagingResult.map(ExhibitionInfoResponse::new);
   }
 
+  @Transactional(readOnly = true)
   public ExhibitionDetailInfoResponse getExhibition(Long userId, Long exhibitionId) {
     ExhibitionDetailForSimpleQuery exhibition = exhibitionRepository
         .findExhibition(userId, exhibitionId)
         .orElseThrow(() -> new InvalidRequestException(EXHB_NOT_FOUND));
 
-    // getReviews()
+    List<ReviewsResponseForExhibitionDetail> reviews = getReviews(userId, exhibitionId);
 
     return ExhibitionDetailInfoResponse.builder()
         .exhibitionId(exhibition.getId())
@@ -65,6 +79,7 @@ public class ExhibitionService {
         .lat(exhibition.getLocation().getLatitude())
         .lng(exhibition.getLocation().getLongitude())
         .isLiked(exhibition.getIsLiked())
+        .reviews(reviews)
         .build();
   }
 
@@ -101,4 +116,19 @@ public class ExhibitionService {
       throw new InvalidRequestException(INVALID_DISTANCE);
     }
   }
+
+  private List<ReviewsResponseForExhibitionDetail> getReviews(Long userId, Long exhibitionId) {
+    List<ReviewWithLikeAndCommentCount> reviews = reviewRepository.findReviewsByExhibitionIdAndUserId(
+        exhibitionId, Objects.isNull(userId) ? null : userId,
+        PageRequest.of(0, 4, Sort.by("reviewLikeCount").descending())).getContent();
+
+    return reviews.stream().map(r -> {
+      Review review = reviewRepository.findById(r.getReviewId())
+          .orElseThrow(() -> new NotFoundException(ErrorCode.REVIEW_NOT_FOUND));
+      List<ReviewPhoto> reviewPhotos = review.getReviewPhotos();
+      User reviewUser = review.getUser();
+      return new ReviewsResponseForExhibitionDetail(r, reviewPhotos, reviewUser);
+    }).collect(Collectors.toList());
+  }
+
 }

--- a/src/main/java/com/prgrms/artzip/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/service/ExhibitionService.java
@@ -5,9 +5,7 @@ import static com.prgrms.artzip.common.ErrorCode.INVALID_COORDINATE;
 import static com.prgrms.artzip.common.ErrorCode.INVALID_DISTANCE;
 import static org.springframework.util.StringUtils.hasText;
 
-import com.prgrms.artzip.common.ErrorCode;
 import com.prgrms.artzip.common.error.exception.InvalidRequestException;
-import com.prgrms.artzip.common.error.exception.NotFoundException;
 import com.prgrms.artzip.exhibition.domain.repository.ExhibitionRepository;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionDetailForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionForSimpleQuery;
@@ -15,29 +13,22 @@ import com.prgrms.artzip.exhibition.dto.projection.ExhibitionWithLocationForSimp
 import com.prgrms.artzip.exhibition.dto.response.ExhibitionAroundMeInfoResponse;
 import com.prgrms.artzip.exhibition.dto.response.ExhibitionDetailInfoResponse;
 import com.prgrms.artzip.exhibition.dto.response.ExhibitionInfoResponse;
-import com.prgrms.artzip.review.domain.Review;
-import com.prgrms.artzip.review.domain.ReviewPhoto;
-import com.prgrms.artzip.review.domain.repository.ReviewRepository;
-import com.prgrms.artzip.review.dto.projection.ReviewWithLikeAndCommentCount;
 import com.prgrms.artzip.review.dto.response.ReviewsResponseForExhibitionDetail;
-import com.prgrms.artzip.user.domain.User;
+import com.prgrms.artzip.review.service.ReviewService;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ExhibitionService {
 
   private final ExhibitionRepository exhibitionRepository;
-  private final ReviewRepository reviewRepository;
+
+  private final ReviewService reviewService;
 
   public Page<ExhibitionInfoResponse> getUpcomingExhibitions(Long userId,
       Pageable pageable) {
@@ -54,13 +45,13 @@ public class ExhibitionService {
     return exhibitionsPagingResult.map(ExhibitionInfoResponse::new);
   }
 
-  @Transactional(readOnly = true)
   public ExhibitionDetailInfoResponse getExhibition(Long userId, Long exhibitionId) {
     ExhibitionDetailForSimpleQuery exhibition = exhibitionRepository
         .findExhibition(userId, exhibitionId)
         .orElseThrow(() -> new InvalidRequestException(EXHB_NOT_FOUND));
 
-    List<ReviewsResponseForExhibitionDetail> reviews = getReviews(userId, exhibitionId);
+    List<ReviewsResponseForExhibitionDetail> reviews = reviewService.getReviewsForExhibition(userId,
+        exhibitionId);
 
     return ExhibitionDetailInfoResponse.builder()
         .exhibitionId(exhibition.getId())
@@ -115,20 +106,6 @@ public class ExhibitionService {
     if (distance <= 0) {
       throw new InvalidRequestException(INVALID_DISTANCE);
     }
-  }
-
-  private List<ReviewsResponseForExhibitionDetail> getReviews(Long userId, Long exhibitionId) {
-    List<ReviewWithLikeAndCommentCount> reviews = reviewRepository.findReviewsByExhibitionIdAndUserId(
-        exhibitionId, Objects.isNull(userId) ? null : userId,
-        PageRequest.of(0, 4, Sort.by("reviewLikeCount").descending())).getContent();
-
-    return reviews.stream().map(r -> {
-      Review review = reviewRepository.findById(r.getReviewId())
-          .orElseThrow(() -> new NotFoundException(ErrorCode.REVIEW_NOT_FOUND));
-      List<ReviewPhoto> reviewPhotos = review.getReviewPhotos();
-      User reviewUser = review.getUser();
-      return new ReviewsResponseForExhibitionDetail(r, reviewPhotos, reviewUser);
-    }).collect(Collectors.toList());
   }
 
 }

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
@@ -10,19 +10,21 @@ import com.prgrms.artzip.review.domain.QReviewLike;
 import com.prgrms.artzip.review.dto.projection.ReviewWithLikeAndCommentCount;
 import com.prgrms.artzip.review.dto.projection.ReviewWithLikeData;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 
 public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
@@ -97,9 +99,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .groupBy(review.id, review.createdAt)
-        .orderBy(review.createdAt.desc())                     // 리뷰 생성 최신순
-//        .orderBy(reviewLike.id.countDistinct().desc())      // 리뷰 좋아요 많은 순
-//        .orderBy(comment.id.countDistinct().desc())         // 댓글 개수 많은 순
+        .orderBy(getAllOrderSpecifiers(pageable).toArray(OrderSpecifier[]::new))
         .fetch();
 
     JPAQuery<Long> countQuery = queryFactory
@@ -129,10 +129,14 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
     }
   }
 
-  // TODO: pageable의 sort 적용
   private List<OrderSpecifier> getAllOrderSpecifiers(Pageable pageable) {
+    if (Objects.nonNull(pageable.getSort())) {
+      return pageable.getSort().get().map(order -> ReviewSortType.valueOf(order.getProperty())
+          .getOrderSpecifier(order.getDirection().isAscending() ? Order.ASC : Order.DESC))
+          .collect(Collectors.toList());
+    }
 
-    return null;
+    return Collections.emptyList();
   }
 
 }

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 
 public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
@@ -130,13 +131,15 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
   }
 
   private List<OrderSpecifier> getAllOrderSpecifiers(Pageable pageable) {
-    if (Objects.nonNull(pageable.getSort())) {
-      return pageable.getSort().get().map(order -> ReviewSortType.valueOf(order.getProperty())
-          .getOrderSpecifier(order.getDirection().isAscending() ? Order.ASC : Order.DESC))
-          .collect(Collectors.toList());
+    if (pageable.getSort().isEmpty()) {
+      return Collections.emptyList();
     }
 
-    return Collections.emptyList();
+    return pageable.getSort().stream()
+        .filter(order -> ReviewSortType.getReviewSortType(order.getProperty()).isPresent())
+        .map(order -> ReviewSortType.getReviewSortType(order.getProperty()).get()
+            .getOrderSpecifier(order.getDirection().isAscending() ? Order.ASC : Order.DESC))
+        .collect(Collectors.toList());
   }
 
 }

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewSortType.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewSortType.java
@@ -1,0 +1,29 @@
+package com.prgrms.artzip.review.domain.repository;
+
+import static com.prgrms.artzip.comment.domain.QComment.comment;
+import static com.prgrms.artzip.review.domain.QReview.review;
+import static com.prgrms.artzip.review.domain.QReviewLike.reviewLike;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+
+public enum ReviewSortType {
+
+  CREATED_AT("createdAt", review.createdAt),
+  REVIEW_LIKE_COUNT("reviewLikeCount", reviewLike.id.countDistinct()),
+  COMMENT_COUNT("commentCount", comment.id.countDistinct());
+
+  private final String property;
+  private final Expression target;
+
+  ReviewSortType(String property, Expression target) {
+    this.property = property;
+    this.target = target;
+  }
+
+  public OrderSpecifier<?> getOrderSpecifier(Order direction) {
+    return new OrderSpecifier(direction, this.target);
+  }
+
+}

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewSortType.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewSortType.java
@@ -7,6 +7,8 @@ import static com.prgrms.artzip.review.domain.QReviewLike.reviewLike;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import java.util.Arrays;
+import java.util.Optional;
 
 public enum ReviewSortType {
 
@@ -24,6 +26,14 @@ public enum ReviewSortType {
 
   public OrderSpecifier<?> getOrderSpecifier(Order direction) {
     return new OrderSpecifier(direction, this.target);
+  }
+
+  public static Optional<ReviewSortType> getReviewSortType(String property) {
+    return Optional.ofNullable(
+        Arrays.stream(ReviewSortType.values())
+            .filter(reviewSortType -> reviewSortType.property.equals(property))
+            .findAny()
+            .orElse(null));
   }
 
 }

--- a/src/main/java/com/prgrms/artzip/review/dto/response/ReviewsResponseForExhibitionDetail.java
+++ b/src/main/java/com/prgrms/artzip/review/dto/response/ReviewsResponseForExhibitionDetail.java
@@ -9,9 +9,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 public class ReviewsResponseForExhibitionDetail {
 
   private Long reviewId;
@@ -43,5 +43,26 @@ public class ReviewsResponseForExhibitionDetail {
     this.likeCount = review.getLikeCount();
     this.commentCount = review.getCommentCount();
     this.photos = photos.stream().map(ReviewPhotoInfo::new).collect(Collectors.toList());
+  }
+
+  @Builder
+  public ReviewsResponseForExhibitionDetail(Long reviewId,
+      ReviewUserInfo user, LocalDate date, String title, String content,
+      LocalDateTime createdAt, LocalDateTime updatedAt, Boolean isEdited, Boolean isLiked,
+      Boolean isPublic, Long likeCount, Long commentCount,
+      List<ReviewPhotoInfo> photos) {
+    this.reviewId = reviewId;
+    this.user = user;
+    this.date = date;
+    this.title = title;
+    this.content = content;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.isEdited = isEdited;
+    this.isLiked = isLiked;
+    this.isPublic = isPublic;
+    this.likeCount = likeCount;
+    this.commentCount = commentCount;
+    this.photos = photos;
   }
 }

--- a/src/main/java/com/prgrms/artzip/review/dto/response/ReviewsResponseForExhibitionDetail.java
+++ b/src/main/java/com/prgrms/artzip/review/dto/response/ReviewsResponseForExhibitionDetail.java
@@ -1,0 +1,45 @@
+package com.prgrms.artzip.review.dto.response;
+
+import com.prgrms.artzip.review.domain.ReviewPhoto;
+import com.prgrms.artzip.review.dto.projection.ReviewWithLikeAndCommentCount;
+import com.prgrms.artzip.user.domain.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReviewsResponseForExhibitionDetail {
+
+  private Long reviewId;
+  private ReviewUserInfo user;
+  private LocalDate date;
+  private String title;
+  private String content;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+  private Boolean isEdited;
+  private Boolean isLiked;
+  private Boolean isPublic;
+  private Long likeCount;
+  private List<ReviewPhotoInfo> photos;
+
+  @Builder
+  public ReviewsResponseForExhibitionDetail(ReviewWithLikeAndCommentCount review,
+      List<ReviewPhoto> photos, User user) {
+    this.reviewId = review.getReviewId();
+    this.user = new ReviewUserInfo(user);
+    this.date = review.getDate();
+    this.title = review.getTitle();
+    this.content = review.getContent();
+    this.createdAt = review.getCreatedAt();
+    this.updatedAt = review.getUpdatedAt();
+    this.isEdited = review.getCreatedAt().isEqual(review.getUpdatedAt()) ? false : true;
+    this.isLiked = review.getIsLiked();
+    this.isPublic = review.getIsPublic();
+    this.likeCount = review.getLikeCount();
+    this.photos = photos.stream().map(ReviewPhotoInfo::new).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/prgrms/artzip/review/dto/response/ReviewsResponseForExhibitionDetail.java
+++ b/src/main/java/com/prgrms/artzip/review/dto/response/ReviewsResponseForExhibitionDetail.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class ReviewsResponseForExhibitionDetail {
 
   private Long reviewId;
@@ -24,9 +25,9 @@ public class ReviewsResponseForExhibitionDetail {
   private Boolean isLiked;
   private Boolean isPublic;
   private Long likeCount;
+  private Long commentCount;
   private List<ReviewPhotoInfo> photos;
 
-  @Builder
   public ReviewsResponseForExhibitionDetail(ReviewWithLikeAndCommentCount review,
       List<ReviewPhoto> photos, User user) {
     this.reviewId = review.getReviewId();
@@ -40,6 +41,7 @@ public class ReviewsResponseForExhibitionDetail {
     this.isLiked = review.getIsLiked();
     this.isPublic = review.getIsPublic();
     this.likeCount = review.getLikeCount();
+    this.commentCount = review.getCommentCount();
     this.photos = photos.stream().map(ReviewPhotoInfo::new).collect(Collectors.toList());
   }
 }

--- a/src/test/java/com/prgrms/artzip/exhibition/service/ExhibitionServiceTest.java
+++ b/src/test/java/com/prgrms/artzip/exhibition/service/ExhibitionServiceTest.java
@@ -6,6 +6,8 @@ import static com.prgrms.artzip.common.ErrorCode.INVALID_DISTANCE;
 import static com.prgrms.artzip.exhibition.domain.enumType.Area.GYEONGGI;
 import static com.prgrms.artzip.exhibition.domain.enumType.Area.SEOUL;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,11 +22,15 @@ import com.prgrms.artzip.exhibition.domain.vo.Period;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionDetailForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionForSimpleQuery;
 import com.prgrms.artzip.exhibition.dto.projection.ExhibitionWithLocationForSimpleQuery;
+import com.prgrms.artzip.review.domain.repository.ReviewRepository;
+import com.prgrms.artzip.review.dto.projection.ReviewWithLikeAndCommentCount;
+import com.prgrms.artzip.review.dto.response.ReviewsResponseForExhibitionDetail;
 import com.prgrms.artzip.user.domain.Role;
 import com.prgrms.artzip.user.domain.User;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -37,6 +43,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ExhibitionService 테스트")
@@ -44,6 +51,9 @@ class ExhibitionServiceTest {
 
   @Mock
   private ExhibitionRepository exhibitionRepository;
+
+  @Mock
+  private ReviewRepository reviewRepository;
 
   @InjectMocks
   private ExhibitionService exhibitionService;
@@ -188,8 +198,12 @@ class ExhibitionServiceTest {
     @Test
     @DisplayName("인증된 사용자이며 좋아요를 누른 경우")
     void testAuthorizedLike() {
+      Page<ReviewWithLikeAndCommentCount> reviews = Page.empty();
       when(exhibitionRepository.findExhibition(userId, exhibitionId))
           .thenReturn(Optional.of(exhibitionDetail1));
+      when(reviewRepository.findReviewsByExhibitionIdAndUserId(exhibitionId, userId,
+          PageRequest.of(0, 4, Sort.by("reviewLikeCount").descending())))
+          .thenReturn(reviews);
 
       exhibitionService.getExhibition(userId, exhibitionId);
 
@@ -199,8 +213,12 @@ class ExhibitionServiceTest {
     @Test
     @DisplayName("인증된 사용자이며 좋아요를 누르지 않은 경우")
     void testAuthorizedNotLike() {
+      Page<ReviewWithLikeAndCommentCount> reviews = Page.empty();
       when(exhibitionRepository.findExhibition(null, exhibitionId))
           .thenReturn(Optional.of(exhibitionDetail2));
+      when(reviewRepository.findReviewsByExhibitionIdAndUserId(exhibitionId, null,
+          PageRequest.of(0, 4, Sort.by("reviewLikeCount").descending())))
+          .thenReturn(reviews);
 
       exhibitionService.getExhibition(null, exhibitionId);
 


### PR DESCRIPTION
## 구현 내용
### 전시회 상세 조회 service에 들어가는 reviews
- service
  - `ExhibitionService.getExhibition`에 `getReviews()` 추가
    - 리뷰 좋아요 많은 순(`reviewLikeCount`, decs), 4개
 - repository
  - API 명세에 맞는 reviews DTO 생성
  - `ExhibitionDetailInfoResponse` DTO 수정
    - reviews 추가
  - `ReviewCustomRepositoryImpl`에서 `pageable의 sort` 적용하도록 수정
    - enum ReviewSortType을 정의하여 sort 적용
      - `CREATED_AT`:  후기 생성순
      - `REVIEW_LIKE_COUNT`: 후기 좋아요순
      - `COMMENT_COUNT`: 후기 댓글순
   
### @yshjft 유석님만 해당
- 일단 기능구현을 우선으로 해서 review를 가져오는 방식으로 구현했습니다.
- 다음에 커스텀 쿼리로 가져오도록 변경하겠습니다.
- 그리고 ReviewsResponseForExhibitionDetail 쪽에서 stubbing이 어려운 부분이 있어서 테스트가 안된 라인이 있습니다.
- 테스트 커버리지 떨어뜨려서 죄송합니다😭
```java
// ExhinitionService.java line 120~132
  private List<ReviewsResponseForExhibitionDetail> getReviews(Long userId, Long exhibitionId) {
    List<ReviewWithLikeAndCommentCount> reviews = reviewRepository.findReviewsByExhibitionIdAndUserId(
        exhibitionId, Objects.isNull(userId) ? null : userId,
        PageRequest.of(0, 4, Sort.by("reviewLikeCount").descending())).getContent();

    return reviews.stream().map(r -> {
      Review review = reviewRepository.findById(r.getReviewId())
          .orElseThrow(() -> new NotFoundException(ErrorCode.REVIEW_NOT_FOUND));
      List<ReviewPhoto> reviewPhotos = review.getReviewPhotos();
      User reviewUser = review.getUser();
      return new ReviewsResponseForExhibitionDetail(r, reviewPhotos, reviewUser);
    }).collect(Collectors.toList());
  }
```