### PR TITLE
리뷰 작성시 전시회 검색 수정

### DIFF
--- a/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryImpl.java
@@ -365,6 +365,7 @@ public class ExhibitionRepositoryImpl implements ExhibitionCustomRepository {
 
     exhibitionsForReviewCondition
         .and(exhibitionNameContains(query))
+        .and(exhibitionStartDateGt())
         .and(exhibitionIsDeletedIsFalse());
 
     return exhibitionsForReviewCondition;
@@ -437,6 +438,10 @@ public class ExhibitionRepositoryImpl implements ExhibitionCustomRepository {
     } else {
       return exhibitionLikeForIsLiked.user.id.eq(userId);
     }
+  }
+
+  private BooleanExpression exhibitionStartDateGt() {
+    return exhibition.period.startDate.loe(LocalDate.now());
   }
 
   private BooleanExpression exhibitionEndDateGoe() {

--- a/src/test/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryTest.java
+++ b/src/test/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryTest.java
@@ -494,11 +494,6 @@ class ExhibitionRepositoryTest {
           .build();
       em.persist(exhibitionGyeonggi);
 
-      System.out.println("시발");
-      System.out.println(LocalDate.now());
-      System.out.println(exhibitionAtBusan.getPeriod().getStartDate());
-      System.out.println(exhibitionGyeonggi.getPeriod().getStartDate());
-
       em.flush();
       em.clear();
     }

--- a/src/test/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryTest.java
+++ b/src/test/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryTest.java
@@ -457,7 +457,7 @@ class ExhibitionRepositoryTest {
       Exhibition exhibitionAtBusan = Exhibition.builder()
           .seq(32)
           .name("전시회 at 부산")
-          .startDate(LocalDate.now().plusDays(10))
+          .startDate(LocalDate.now().minusDays(5))
           .endDate(LocalDate.now().plusDays(15))
           .genre(Genre.FINEART)
           .description("이것은 전시회 설명입니다.")
@@ -474,6 +474,31 @@ class ExhibitionRepositoryTest {
           .build();
       em.persist(exhibitionAtBusan);
 
+      Exhibition exhibitionGyeonggi = Exhibition.builder()
+          .seq(34)
+          .name("전시회 at 경기")
+          .startDate(LocalDate.now().plusDays(20))
+          .endDate(LocalDate.now().plusDays(30))
+          .genre(Genre.FINEART)
+          .description("이것은 전시회 설명입니다.")
+          .latitude(37.22)
+          .longitude(129.02)
+          .area(GYEONGGI)
+          .place("미술관")
+          .address("경기도 성남시")
+          .inquiry("문의처 정보")
+          .fee("성인 20,000원")
+          .thumbnail("http://www.culture.go.kr/upload/rdf/22/07/show_2022072010193392447.jpg")
+          .url("https://www.example.com")
+          .placeUrl("https://www.place-example.com")
+          .build();
+      em.persist(exhibitionGyeonggi);
+
+      System.out.println("시발");
+      System.out.println(LocalDate.now());
+      System.out.println(exhibitionAtBusan.getPeriod().getStartDate());
+      System.out.println(exhibitionGyeonggi.getPeriod().getStartDate());
+
       em.flush();
       em.clear();
     }
@@ -483,7 +508,7 @@ class ExhibitionRepositoryTest {
     @DisplayName("검색어에 맞는 결과가 반환되는지 테스트")
     void testFindExhibitionsForReview() {
       List<ExhibitionBasicForSimpleQuery> exhibitions = exhibitionRepository.findExhibitionsForReview(
-          "부산");
+          "전시");
 
       assertThat(exhibitions).hasSize(1);
       assertThat(exhibitions.get(0))


### PR DESCRIPTION
## 구현 내용
### 리뷰 작성시 전시회 검색 수정
* 리뷰 작성시 전시회 검색에서 시작 전인 전시회 반환되지 않도록 수정하였습니다.
* 수정된 기능에 따라 테스트 코드 또한 수정 하였습니다.