### PR TITLE
페이징 오류 수정

### DIFF
--- a/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/domain/repository/ExhibitionRepositoryImpl.java
@@ -35,10 +35,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
+@Slf4j
 @RequiredArgsConstructor
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ExhibitionRepositoryImpl implements ExhibitionCustomRepository {
@@ -57,7 +59,9 @@ public class ExhibitionRepositoryImpl implements ExhibitionCustomRepository {
     List<ExhibitionForSimpleQuery> exhibitions = findExhibitions(userId, upcomingCondition,
         Arrays.asList(
             new OrderSpecifier(Order.ASC, exhibition.period.startDate),
-            new OrderSpecifier(Order.ASC, exhibition.period.endDate)),
+            new OrderSpecifier(Order.ASC, exhibition.period.endDate),
+            new OrderSpecifier(Order.ASC, exhibition.id)
+        ),
         pageable);
 
     JPAQuery<Long> countQuery = getExhibitionCountQuery(upcomingCondition);
@@ -72,7 +76,10 @@ public class ExhibitionRepositoryImpl implements ExhibitionCustomRepository {
 
     List<ExhibitionForSimpleQuery> exhibitions = findExhibitions(userId,
         mostLikeCondition,
-        List.of(new OrderSpecifier(Order.DESC, Expressions.numberPath(Long.class, "likeCount"))),
+        List.of(
+            new OrderSpecifier(Order.DESC, Expressions.numberPath(Long.class, "likeCount")),
+            new OrderSpecifier(Order.ASC, exhibition.id)
+        ),
         pageable);
 
     JPAQuery<Long> countQuery = getExhibitionCountQuery(mostLikeCondition);
@@ -187,7 +194,10 @@ public class ExhibitionRepositoryImpl implements ExhibitionCustomRepository {
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .groupBy(exhibition.id, exhibitionLikeForExhibitionLikeUser.createdAt)
-        .orderBy(exhibitionLikeForExhibitionLikeUser.createdAt.desc())
+        .orderBy(
+            exhibitionLikeForExhibitionLikeUser.createdAt.desc(),
+            exhibition.id.asc()
+        )
         .fetch();
 
     JPAQuery<Long> countQuery = queryFactory
@@ -208,7 +218,10 @@ public class ExhibitionRepositoryImpl implements ExhibitionCustomRepository {
     BooleanBuilder customCondition = getCustomCondition(exhibitionCustomCondition);
 
     List<ExhibitionForSimpleQuery> exhibitions = findExhibitions(userId, customCondition,
-        List.of(new OrderSpecifier(Order.ASC, exhibition.period.startDate)),
+        List.of(
+            new OrderSpecifier(Order.ASC, exhibition.period.startDate),
+            new OrderSpecifier(Order.ASC, exhibition.id)
+        ),
         pageable);
 
     JPAQuery<Long> countQuery = getExhibitionCountQuery(customCondition);
@@ -248,7 +261,6 @@ public class ExhibitionRepositoryImpl implements ExhibitionCustomRepository {
         .groupBy(exhibition.id)
         .fetch();
   }
-
 
   @Override
   public Optional<ReviewExhibitionInfo> findExhibitionForReview(
@@ -291,6 +303,7 @@ public class ExhibitionRepositoryImpl implements ExhibitionCustomRepository {
 
   private List<ExhibitionForSimpleQuery> findExhibitions(Long userId, BooleanBuilder condition,
       List<OrderSpecifier> orders, Pageable pageable) {
+
     return queryFactory
         .select(Projections.fields(ExhibitionForSimpleQuery.class,
                 exhibition.id,

--- a/src/main/java/com/prgrms/artzip/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/prgrms/artzip/exhibition/service/ExhibitionService.java
@@ -33,8 +33,7 @@ public class ExhibitionService {
     return exhibitionsPagingResult.map(ExhibitionInfoResponse::new);
   }
 
-  public Page<ExhibitionInfoResponse> getMostLikeExhibitions(Long userId,
-      boolean includeEnd,
+  public Page<ExhibitionInfoResponse> getMostLikeExhibitions(Long userId, boolean includeEnd,
       Pageable pageable) {
     Page<ExhibitionForSimpleQuery> exhibitionsPagingResult = exhibitionRepository
         .findMostLikeExhibitions(userId, includeEnd, pageable);

--- a/src/test/java/com/prgrms/artzip/exhibition/service/ExhibitionServiceTest.java
+++ b/src/test/java/com/prgrms/artzip/exhibition/service/ExhibitionServiceTest.java
@@ -6,6 +6,7 @@ import static com.prgrms.artzip.common.ErrorCode.INVALID_DISTANCE;
 import static com.prgrms.artzip.exhibition.domain.enumType.Area.GYEONGGI;
 import static com.prgrms.artzip.exhibition.domain.enumType.Area.SEOUL;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -217,6 +218,8 @@ class ExhibitionServiceTest {
       assertThatThrownBy(() -> exhibitionService.getExhibition(null, exhibitionId))
           .isInstanceOf(InvalidRequestException.class)
           .hasMessage(EXHB_NOT_FOUND.getMessage());
+
+      verify(reviewService, never()).getReviewsForExhibition(null, exhibitionId);
     }
 
     @Test


### PR DESCRIPTION
## 구현 내용
### 인기 많은 전시회 조회 페이징 오류 수정
* 인기 많은 전시회 페이징 조회시 정렬 기준 누락으로 중복된 데이터가 등장하는 문제를 해결하였습니다.

### 전시회 상세 조회 테스트 코드를 수정
* 전시회 상세 조회 테스트 코드를 아주 약간 수정하였습니다.