### PR TITLE
review domain 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 
 public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
@@ -93,7 +92,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
         .leftJoin(reviewLikeToGetIsLiked).on(reviewLikeToGetIsLiked.review.eq(review),
             alwaysFalse().or(reviewLikeUserIdEq(userId)))
         .leftJoin(reviewLike).on(review.id.eq(reviewLike.review.id))
-        .leftJoin(comment).on(review.id.eq(comment.review.id))
+        .leftJoin(comment).on(review.id.eq(comment.review.id), comment.isDeleted.isFalse())
         .where(review.isDeleted.eq(false),
             review.isPublic.eq(true),
             reviewExhibitionIdEq(exhibitionId))
@@ -137,7 +136,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
         .leftJoin(reviewLikeToGetIsLiked).on(reviewLikeToGetIsLiked.review.eq(review),
             alwaysFalse().or(reviewLikeUserIdEq(currentUserId)))
         .leftJoin(reviewLike).on(review.id.eq(reviewLike.review.id))
-        .leftJoin(comment).on(review.id.eq(comment.review.id))
+        .leftJoin(comment).on(review.id.eq(comment.review.id), comment.isDeleted.isFalse())
         .where(review.isDeleted.eq(false),
             review.isPublic.eq(true),
             reviewLikeTargetUserIdEq(targetUserId))

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
@@ -186,7 +186,6 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
         .leftJoin(reviewLike).on(review.id.eq(reviewLike.review.id))
         .leftJoin(comment).on(review.id.eq(comment.review.id), comment.isDeleted.isFalse())
         .where(review.isDeleted.isFalse(),
-            review.isPublic.isTrue(),
             reviewTargetUserIdEq(targetUserId),
             filterIsNotPublic(currentUserId))
         .offset(pageable.getOffset())
@@ -199,7 +198,6 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
         .select(review.count())
         .from(review)
         .where(review.isDeleted.isFalse(),
-            review.isPublic.isTrue(),
             reviewTargetUserIdEq(targetUserId),
             filterIsNotPublic(currentUserId));
 

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
@@ -31,7 +31,10 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
 
   private final JPAQueryFactory queryFactory;
 
+  // like count 계산할 때 사용
   private final QReviewLike reviewLikeToGetIsLiked = new QReviewLike("reviewLikeToGetIsLiked");
+  // target user의 like를 필터링할 때 사용
+  private final QReviewLike reviewLikeToFilterTargetUser = new QReviewLike("reviewLikeToFilterTargetUser");
 
   public ReviewCustomRepositoryImpl(EntityManager entityManager) {
     this.queryFactory = new JPAQueryFactory(entityManager);
@@ -136,6 +139,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
         .leftJoin(reviewLikeToGetIsLiked).on(reviewLikeToGetIsLiked.review.eq(review),
             alwaysFalse().or(reviewLikeUserIdEq(currentUserId)))
         .leftJoin(reviewLike).on(review.id.eq(reviewLike.review.id))
+        .leftJoin(reviewLikeToFilterTargetUser).on(review.id.eq(reviewLikeToFilterTargetUser.review.id))
         .leftJoin(comment).on(review.id.eq(comment.review.id), comment.isDeleted.isFalse())
         .where(review.isDeleted.eq(false),
             review.isPublic.eq(true),
@@ -207,7 +211,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
   }
 
   private BooleanBuilder reviewLikeTargetUserIdEq(Long targetUserId) {
-    return nullSafeBooleanBuilder(() -> reviewLike.user.id.eq(targetUserId));
+    return nullSafeBooleanBuilder(() -> reviewLikeToFilterTargetUser.user.id.eq(targetUserId));
   }
 
   private BooleanBuilder reviewExhibitionIdEq(Long exhibitionId) {

--- a/src/test/java/com/prgrms/artzip/review/domain/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/prgrms/artzip/review/domain/repository/ReviewRepositoryTest.java
@@ -46,7 +46,7 @@ public class ReviewRepositoryTest {
   private User user1, user2, user3;
   private Exhibition exhibitionAtBusan, exhibitionAtSeoul, exhibitionAlreadyEnd;
   private Review publicReview1, publicReview2, publicReview3, privateReview, deletedReview;
-  private ReviewLike reviewLike1, reviewLike2, reviewLike3;
+  private ReviewLike reviewLike1, reviewLike2, reviewLike3, reviewLike4;
 
   int commentCountOfPublicReview1 = 30;
   int commentCountOfPublicReview2 = 20;
@@ -176,6 +176,8 @@ public class ReviewRepositoryTest {
     em.persist(reviewLike2);
     reviewLike3 = new ReviewLike(privateReview, user3);
     em.persist(reviewLike3);
+    reviewLike4 = new ReviewLike(publicReview2, user1);
+    em.persist(reviewLike4);
 
     for (int i = 0; i < commentCountOfPublicReview1; i++) {
       Comment comment = Comment.builder()
@@ -367,7 +369,7 @@ public class ReviewRepositoryTest {
         assertThat(content.get(1))
             .hasFieldOrPropertyWithValue("commentCount", 60L)
             .hasFieldOrPropertyWithValue("isLiked", false)
-            .hasFieldOrPropertyWithValue("likeCount", 0L)
+            .hasFieldOrPropertyWithValue("likeCount", 1L)
             .hasFieldOrPropertyWithValue("reviewId", publicReview2.getId())
             .hasFieldOrPropertyWithValue("date", publicReview2.getDate())
             .hasFieldOrPropertyWithValue("title", publicReview2.getTitle())
@@ -404,8 +406,8 @@ public class ReviewRepositoryTest {
             .hasFieldOrPropertyWithValue("isPublic", true);
         assertThat(content.get(1))
             .hasFieldOrPropertyWithValue("commentCount", 60L)
-            .hasFieldOrPropertyWithValue("isLiked", false)
-            .hasFieldOrPropertyWithValue("likeCount", 0L)
+            .hasFieldOrPropertyWithValue("isLiked", true)
+            .hasFieldOrPropertyWithValue("likeCount", 1L)
             .hasFieldOrPropertyWithValue("reviewId", publicReview2.getId())
             .hasFieldOrPropertyWithValue("date", publicReview2.getDate())
             .hasFieldOrPropertyWithValue("title", publicReview2.getTitle())
@@ -441,7 +443,7 @@ public class ReviewRepositoryTest {
         assertThat(content.get(0))
             .hasFieldOrPropertyWithValue("commentCount", 60L)
             .hasFieldOrPropertyWithValue("isLiked", false)
-            .hasFieldOrPropertyWithValue("likeCount", 0L)
+            .hasFieldOrPropertyWithValue("likeCount", 1L)
             .hasFieldOrPropertyWithValue("reviewId", publicReview2.getId())
             .hasFieldOrPropertyWithValue("date", publicReview2.getDate())
             .hasFieldOrPropertyWithValue("title", publicReview2.getTitle())
@@ -469,8 +471,8 @@ public class ReviewRepositoryTest {
         List<ReviewWithLikeAndCommentCount> content = result.getContent();
         assertThat(content.get(0))
             .hasFieldOrPropertyWithValue("commentCount", 60L)
-            .hasFieldOrPropertyWithValue("isLiked", false)
-            .hasFieldOrPropertyWithValue("likeCount", 0L)
+            .hasFieldOrPropertyWithValue("isLiked", true)
+            .hasFieldOrPropertyWithValue("likeCount", 1L)
             .hasFieldOrPropertyWithValue("reviewId", publicReview2.getId())
             .hasFieldOrPropertyWithValue("date", publicReview2.getDate())
             .hasFieldOrPropertyWithValue("title", publicReview2.getTitle())
@@ -488,6 +490,82 @@ public class ReviewRepositoryTest {
       }
 
     }
+
+  }
+
+  @Nested
+  @DisplayName("findMyLikesReviews() 테스트: 유저가 좋아요한 후기 다건 조회")
+  class TestFindMyLikesReviews {
+
+    Pageable pageable = PageRequest.of(0, 20, Sort.by("createdAt").descending());
+
+      @Test
+      @DisplayName("currentUserId == null인 경우, isLiked(좋아요 여부)는 조회되지 않는다.")
+      void testCurrentUserIdIsNull() {
+
+        Page<ReviewWithLikeAndCommentCount> result = reviewRepository.findMyLikesReviews(
+            null, user1.getId(), pageable);
+
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        List<ReviewWithLikeAndCommentCount> content = result.getContent();
+        assertThat(content.get(0))
+            .hasFieldOrPropertyWithValue("commentCount", 60L)
+            .hasFieldOrPropertyWithValue("isLiked", false)
+            .hasFieldOrPropertyWithValue("likeCount", 1L)
+            .hasFieldOrPropertyWithValue("reviewId", publicReview2.getId())
+            .hasFieldOrPropertyWithValue("date", publicReview2.getDate())
+            .hasFieldOrPropertyWithValue("title", publicReview2.getTitle())
+            .hasFieldOrPropertyWithValue("content", publicReview2.getContent())
+            .hasFieldOrPropertyWithValue("isPublic", true);
+        assertThat(content.get(1))
+            .hasFieldOrPropertyWithValue("commentCount", 75L)
+            .hasFieldOrPropertyWithValue("isLiked", false)
+            .hasFieldOrPropertyWithValue("likeCount", 2L)
+            .hasFieldOrPropertyWithValue("reviewId", publicReview1.getId())
+            .hasFieldOrPropertyWithValue("date", publicReview1.getDate())
+            .hasFieldOrPropertyWithValue("title", publicReview1.getTitle())
+            .hasFieldOrPropertyWithValue("content", publicReview1.getContent())
+            .hasFieldOrPropertyWithValue("isPublic", true);
+      }
+
+      @Test
+      @DisplayName("currentUserId != null인 경우, isLiked(좋아요 여부)도 함께 조회된다.")
+      void testCurrentUserIdInNotNull() {
+        Page<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewsByExhibitionIdAndUserId(
+            null, user1.getId(), pageable);
+
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.getTotalElements()).isEqualTo(3);
+        List<ReviewWithLikeAndCommentCount> content = result.getContent();
+        assertThat(content.get(0))
+            .hasFieldOrPropertyWithValue("commentCount", 0L)
+            .hasFieldOrPropertyWithValue("isLiked", false)
+            .hasFieldOrPropertyWithValue("likeCount", 0L)
+            .hasFieldOrPropertyWithValue("reviewId", publicReview3.getId())
+            .hasFieldOrPropertyWithValue("date", publicReview3.getDate())
+            .hasFieldOrPropertyWithValue("title", publicReview3.getTitle())
+            .hasFieldOrPropertyWithValue("content", publicReview3.getContent())
+            .hasFieldOrPropertyWithValue("isPublic", true);
+        assertThat(content.get(1))
+            .hasFieldOrPropertyWithValue("commentCount", 60L)
+            .hasFieldOrPropertyWithValue("isLiked", true)
+            .hasFieldOrPropertyWithValue("likeCount", 1L)
+            .hasFieldOrPropertyWithValue("reviewId", publicReview2.getId())
+            .hasFieldOrPropertyWithValue("date", publicReview2.getDate())
+            .hasFieldOrPropertyWithValue("title", publicReview2.getTitle())
+            .hasFieldOrPropertyWithValue("content", publicReview2.getContent())
+            .hasFieldOrPropertyWithValue("isPublic", true);
+        assertThat(content.get(2))
+            .hasFieldOrPropertyWithValue("commentCount", 75L)
+            .hasFieldOrPropertyWithValue("isLiked", true)
+            .hasFieldOrPropertyWithValue("likeCount", 2L)
+            .hasFieldOrPropertyWithValue("reviewId", publicReview1.getId())
+            .hasFieldOrPropertyWithValue("date", publicReview1.getDate())
+            .hasFieldOrPropertyWithValue("title", publicReview1.getTitle())
+            .hasFieldOrPropertyWithValue("content", publicReview1.getContent())
+            .hasFieldOrPropertyWithValue("isPublic", true);
+      }
 
   }
 

--- a/src/test/java/com/prgrms/artzip/review/domain/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/prgrms/artzip/review/domain/repository/ReviewRepositoryTest.java
@@ -210,6 +210,9 @@ public class ReviewRepositoryTest {
           .user(user1)
           .parent(parentComment)
           .build();
+      if (i % 2 == 0) {
+        childrenComment1.softDelete();
+      }
       em.persist(childrenComment1);
       Comment childrenComment2 = Comment.builder()
           .content(String.valueOf(i) + "의 자식2")
@@ -371,7 +374,7 @@ public class ReviewRepositoryTest {
             .hasFieldOrPropertyWithValue("content", publicReview2.getContent())
             .hasFieldOrPropertyWithValue("isPublic", true);
         assertThat(content.get(2))
-            .hasFieldOrPropertyWithValue("commentCount", 90L)
+            .hasFieldOrPropertyWithValue("commentCount", 75L)
             .hasFieldOrPropertyWithValue("isLiked", false)
             .hasFieldOrPropertyWithValue("likeCount", 2L)
             .hasFieldOrPropertyWithValue("reviewId", publicReview1.getId())
@@ -409,7 +412,7 @@ public class ReviewRepositoryTest {
             .hasFieldOrPropertyWithValue("content", publicReview2.getContent())
             .hasFieldOrPropertyWithValue("isPublic", true);
         assertThat(content.get(2))
-            .hasFieldOrPropertyWithValue("commentCount", 90L)
+            .hasFieldOrPropertyWithValue("commentCount", 75L)
             .hasFieldOrPropertyWithValue("isLiked", true)
             .hasFieldOrPropertyWithValue("likeCount", 2L)
             .hasFieldOrPropertyWithValue("reviewId", publicReview1.getId())
@@ -445,7 +448,7 @@ public class ReviewRepositoryTest {
             .hasFieldOrPropertyWithValue("content", publicReview2.getContent())
             .hasFieldOrPropertyWithValue("isPublic", true);
         assertThat(content.get(1))
-            .hasFieldOrPropertyWithValue("commentCount", 90L)
+            .hasFieldOrPropertyWithValue("commentCount", 75L)
             .hasFieldOrPropertyWithValue("isLiked", false)
             .hasFieldOrPropertyWithValue("likeCount", 2L)
             .hasFieldOrPropertyWithValue("reviewId", publicReview1.getId())
@@ -474,7 +477,7 @@ public class ReviewRepositoryTest {
             .hasFieldOrPropertyWithValue("content", publicReview2.getContent())
             .hasFieldOrPropertyWithValue("isPublic", true);
         assertThat(content.get(1))
-            .hasFieldOrPropertyWithValue("commentCount", 90L)
+            .hasFieldOrPropertyWithValue("commentCount", 75L)
             .hasFieldOrPropertyWithValue("isLiked", true)
             .hasFieldOrPropertyWithValue("likeCount", 2L)
             .hasFieldOrPropertyWithValue("reviewId", publicReview1.getId())

--- a/src/test/java/com/prgrms/artzip/review/domain/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/prgrms/artzip/review/domain/repository/ReviewRepositoryTest.java
@@ -560,4 +560,62 @@ public class ReviewRepositoryTest {
 
   }
 
+  @Nested
+  @DisplayName("findMyReviews() 테스트: 유저가 작성한 후기 다건 조회")
+  class TestFindMyReviews {
+
+    Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+
+    @Test
+    @DisplayName("currentUserId == null인 경우, isLiked(좋아요 여부)는 조회되지 않는다.")
+    void testCurrentUserIdIsNull() {
+
+      Page<ReviewWithLikeAndCommentCount> result = reviewRepository.findMyReviews(
+          null, user1.getId(), pageable);
+
+      assertThat(result.getTotalPages()).isEqualTo(1);
+      assertThat(result.getTotalElements()).isEqualTo(1);
+      List<ReviewWithLikeAndCommentCount> content = result.getContent();
+      assertThat(content.get(0))
+          .hasFieldOrPropertyWithValue("commentCount", 75L)
+          .hasFieldOrPropertyWithValue("isLiked", false)
+          .hasFieldOrPropertyWithValue("likeCount", 2L)
+          .hasFieldOrPropertyWithValue("reviewId", publicReview1.getId())
+          .hasFieldOrPropertyWithValue("date", publicReview1.getDate())
+          .hasFieldOrPropertyWithValue("title", publicReview1.getTitle())
+          .hasFieldOrPropertyWithValue("content", publicReview1.getContent())
+          .hasFieldOrPropertyWithValue("isPublic", true);
+    }
+
+    @Test
+    @DisplayName("currentUserId != null인 경우, isLiked(좋아요 여부)도 함께 조회된다.")
+    void testCurrentUserIdInNotNull() {
+      Page<ReviewWithLikeAndCommentCount> result = reviewRepository.findMyReviews(
+          user1.getId(), user1.getId(), pageable);
+
+      assertThat(result.getTotalPages()).isEqualTo(1);
+      assertThat(result.getTotalElements()).isEqualTo(2);
+      List<ReviewWithLikeAndCommentCount> content = result.getContent();
+      assertThat(content.get(0))
+          .hasFieldOrPropertyWithValue("commentCount", 0L)
+          .hasFieldOrPropertyWithValue("isLiked", false)
+          .hasFieldOrPropertyWithValue("likeCount", 1L)
+          .hasFieldOrPropertyWithValue("reviewId", privateReview.getId())
+          .hasFieldOrPropertyWithValue("date", privateReview.getDate())
+          .hasFieldOrPropertyWithValue("title", privateReview.getTitle())
+          .hasFieldOrPropertyWithValue("content", privateReview.getContent())
+          .hasFieldOrPropertyWithValue("isPublic", false);
+      assertThat(content.get(1))
+          .hasFieldOrPropertyWithValue("commentCount", 75L)
+          .hasFieldOrPropertyWithValue("isLiked", true)
+          .hasFieldOrPropertyWithValue("likeCount", 2L)
+          .hasFieldOrPropertyWithValue("reviewId", publicReview1.getId())
+          .hasFieldOrPropertyWithValue("date", publicReview1.getDate())
+          .hasFieldOrPropertyWithValue("title", publicReview1.getTitle())
+          .hasFieldOrPropertyWithValue("content", publicReview1.getContent())
+          .hasFieldOrPropertyWithValue("isPublic", true);
+    }
+
+  }
+
 }

--- a/src/test/java/com/prgrms/artzip/review/domain/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/prgrms/artzip/review/domain/repository/ReviewRepositoryTest.java
@@ -532,31 +532,22 @@ public class ReviewRepositoryTest {
       @Test
       @DisplayName("currentUserId != null인 경우, isLiked(좋아요 여부)도 함께 조회된다.")
       void testCurrentUserIdInNotNull() {
-        Page<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewsByExhibitionIdAndUserId(
-            null, user1.getId(), pageable);
+        Page<ReviewWithLikeAndCommentCount> result = reviewRepository.findMyLikesReviews(
+            user2.getId(), user1.getId(), pageable);
 
         assertThat(result.getTotalPages()).isEqualTo(1);
-        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result.getTotalElements()).isEqualTo(2);
         List<ReviewWithLikeAndCommentCount> content = result.getContent();
         assertThat(content.get(0))
-            .hasFieldOrPropertyWithValue("commentCount", 0L)
-            .hasFieldOrPropertyWithValue("isLiked", false)
-            .hasFieldOrPropertyWithValue("likeCount", 0L)
-            .hasFieldOrPropertyWithValue("reviewId", publicReview3.getId())
-            .hasFieldOrPropertyWithValue("date", publicReview3.getDate())
-            .hasFieldOrPropertyWithValue("title", publicReview3.getTitle())
-            .hasFieldOrPropertyWithValue("content", publicReview3.getContent())
-            .hasFieldOrPropertyWithValue("isPublic", true);
-        assertThat(content.get(1))
             .hasFieldOrPropertyWithValue("commentCount", 60L)
-            .hasFieldOrPropertyWithValue("isLiked", true)
+            .hasFieldOrPropertyWithValue("isLiked", false)
             .hasFieldOrPropertyWithValue("likeCount", 1L)
             .hasFieldOrPropertyWithValue("reviewId", publicReview2.getId())
             .hasFieldOrPropertyWithValue("date", publicReview2.getDate())
             .hasFieldOrPropertyWithValue("title", publicReview2.getTitle())
             .hasFieldOrPropertyWithValue("content", publicReview2.getContent())
             .hasFieldOrPropertyWithValue("isPublic", true);
-        assertThat(content.get(2))
+        assertThat(content.get(1))
             .hasFieldOrPropertyWithValue("commentCount", 75L)
             .hasFieldOrPropertyWithValue("isLiked", true)
             .hasFieldOrPropertyWithValue("likeCount", 2L)


### PR DESCRIPTION
## 구현 내용
### review domain 조회 쿼리 수정
- comment 조회 시, deleted=true인 comment은 제외하도록 수정
- `유저가 좋아요한 후기 다건 조회`에서 likeCount 오류 수정
- `유저가 쓴 후기 다건 조회`에서 로그인 여부에 따라 review.is_public=true 조건이 들어가도록 수정

### review domain repository test 수정 및 추가
- comment.is_deleted=ture인 경우의 테스트 조건 추가
- `유저가 좋아요한 후기 다건 조회` 테스트 작성
- `유저가 작성한 후기 다건 조회` 테스트 작성