### PR TITLE
소셜로그인(카카오) redirect 로직 추가

### DIFF
--- a/src/main/java/com/prgrms/artzip/common/util/CookieUtil.java
+++ b/src/main/java/com/prgrms/artzip/common/util/CookieUtil.java
@@ -1,0 +1,47 @@
+package com.prgrms.artzip.common.util;
+
+import java.util.Optional;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import static java.util.Objects.*;
+
+public class CookieUtil {
+  public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+    Cookie[] cookies = request.getCookies();
+
+    if (!isNull(cookies) && cookies.length > 0) {
+      for (Cookie cookie : cookies) {
+        if (name.equals(cookie.getName())) {
+          return Optional.of(cookie);
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+    Cookie cookie = new Cookie(name, value);
+    cookie.setPath("/");
+    cookie.setHttpOnly(true);
+    cookie.setMaxAge(maxAge);
+
+    response.addCookie(cookie);
+  }
+
+  public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+    Cookie[] cookies = request.getCookies();
+
+    if (!isNull(cookies) && cookies.length > 0) {
+      for (Cookie cookie : cookies) {
+        if (name.equals(cookie.getName())) {
+          cookie.setValue("");
+          cookie.setPath("/");
+          cookie.setMaxAge(0);
+          response.addCookie(cookie);
+        }
+      }
+    }
+  }
+
+}

--- a/src/main/java/com/prgrms/artzip/common/util/JwtService.java
+++ b/src/main/java/com/prgrms/artzip/common/util/JwtService.java
@@ -41,6 +41,10 @@ public class JwtService {
     this.redisService = redisService;
   }
 
+  public int getRefreshExpiry() {
+    return refreshJwt.getExpirySeconds();
+  }
+
   public String createAccessToken(Long userId, String email, List<GrantedAuthority> authorities) {
     String[] roles = authorities.stream()
         .map(GrantedAuthority::getAuthority)


### PR DESCRIPTION
## 구현 내용
### redirect 로직 추가
* sendRedirect을 통해 인증 성공 시 http://localhost:3000/oauth/callback url로 연결
### response 변경
* sendRedirect을 하면서 body를 보내는 방법을 찾지 못해 response 방식 변경
* accessToken과 userId는 query parameter로, refreshToken은 httponly cookie로 설정해서 줌.

### TODO
* 다른 provider도 지원 가능하도록 getAttribute 부분 추상화
* 로그인과 토큰 재발행 시에 refreshToken도 httpOnly cookie로 설정