### PR TITLE
refresh token cookie로 전달에서 쿼리 파라미터로 전달로 수정

### DIFF
--- a/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -59,11 +59,8 @@ public class OAuth2AuthenticationSuccessHandler extends
     String accessToken = generateAccessToken(user);
     String refreshToken = generateRefreshToken(user);
 
-    int cookieMaxAge = jwtService.getRefreshExpiry() / 1000;
-    CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
-    CookieUtil.addCookie(response, REFRESH_TOKEN, refreshToken, cookieMaxAge);
-
     return UriComponentsBuilder.fromUriString(targetUri)
+        .queryParam("refreshToken", refreshToken)
         .queryParam("accessToken", accessToken)
         .queryParam("userId", user.getId())
         .build().toUriString();


### PR DESCRIPTION
## 구현 내용
### refresh token을 쿼리 파라미터로 전달
* refresh token을 쿠키로 설정하였으나, 프론트에서 쿠키 받지 못하는 상황 발생
* 프론트와 백 도메인이 연관관계가 없어 생기는 문제였음.
* 일단은 임시방편으로 쿼리파라미터로 전달