### PR TITLE
소셜로그인 확장성 있게 리팩토링

### DIFF
--- a/src/main/java/com/prgrms/artzip/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/artzip/common/ErrorCode.java
@@ -47,6 +47,9 @@ public enum ErrorCode {
   REDIS_TOKEN_NOT_FOUND(500, "U015", "유저에 해당하는 토큰을 찾을 수 없습니다."),
   TOKEN_USER_ID_NOT_MATCHED(400, "U016", "액세스 토큰과 유저 아이디가 매치되지 않습니다."),
   BLACKLIST_TOKEN_REQUEST(400, "U017", "로그아웃 처리된 토큰으로 요청할 수 없습니다."),
+  OAUTH_PROVIDER_UNSUPPORTED(500, "U018", "아직 지원되지 않은 소셜로그인입니다."),
+
+  OAUTH_EMAIL_REQUIRED(500, "U019", "OAuth email을 수집하는데 실패하였습니다."),
   /**
    * Exhibition Domain
    */

--- a/src/main/java/com/prgrms/artzip/common/config/JwtConfig.java
+++ b/src/main/java/com/prgrms/artzip/common/config/JwtConfig.java
@@ -1,11 +1,15 @@
 package com.prgrms.artzip.common.config;
 
+import com.prgrms.artzip.common.jwt.Jwt;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
-@Component
+@Configuration
 @ConfigurationProperties(prefix = "spring.jwt")
 @Getter
 @Setter
@@ -25,5 +29,23 @@ public class JwtConfig {
         public String toString() {
             return "header: "+header+" expirySeconds: "+expirySeconds;
         }
+    }
+
+    @Bean
+    @Qualifier("accessJwt")
+    public Jwt accessJwt() {
+        return new Jwt(
+            this.issuer,
+            this.clientSecret,
+            this.accessToken.expirySeconds);
+    }
+
+    @Bean
+    @Qualifier("refreshJwt")
+    public Jwt refreshJwt() {
+        return new Jwt(
+            this.issuer,
+            this.clientSecret,
+            this.refreshToken.expirySeconds);
     }
 }

--- a/src/main/java/com/prgrms/artzip/common/config/JwtConfig.java
+++ b/src/main/java/com/prgrms/artzip/common/config/JwtConfig.java
@@ -1,6 +1,11 @@
 package com.prgrms.artzip.common.config;
 
 import com.prgrms.artzip.common.jwt.Jwt;
+import com.prgrms.artzip.common.jwt.JwtAuthenticationFilter;
+import com.prgrms.artzip.common.jwt.JwtAuthenticationProvider;
+import com.prgrms.artzip.common.util.JwtService;
+import com.prgrms.artzip.user.service.UserService;
+import com.prgrms.artzip.user.service.UserUtilService;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -47,5 +52,18 @@ public class JwtConfig {
             this.issuer,
             this.clientSecret,
             this.refreshToken.expirySeconds);
+    }
+
+    @Bean
+    public JwtAuthenticationProvider jwtAuthenticationProvider(JwtService jwtService,
+        UserService userService) {
+        return new JwtAuthenticationProvider(jwtService, userService);
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtService jwtService,
+        UserUtilService userUtilService) {
+        return new JwtAuthenticationFilter(this.accessToken.header, jwtService,
+            userUtilService);
     }
 }

--- a/src/main/java/com/prgrms/artzip/common/config/WebConfig.java
+++ b/src/main/java/com/prgrms/artzip/common/config/WebConfig.java
@@ -26,7 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/api/v1/**")
-        .allowedOriginPatterns("*")
+        .allowedOrigins("http://localhost:3000", "https://artzip.shop", "https://team-back-fro-art-zip-fe.vercel.app")
         .allowedMethods(
             HttpMethod.GET.name(),
             HttpMethod.HEAD.name(),

--- a/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
@@ -1,25 +1,21 @@
 package com.prgrms.artzip.common.config;
 
-import static com.prgrms.artzip.common.Authority.*;
+import static com.prgrms.artzip.common.Authority.ADMIN;
+import static com.prgrms.artzip.common.Authority.USER;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prgrms.artzip.common.ErrorCode;
 import com.prgrms.artzip.common.ErrorResponse;
 import com.prgrms.artzip.common.filter.ExceptionHandlerFilter;
-import com.prgrms.artzip.common.jwt.Jwt;
 import com.prgrms.artzip.common.jwt.JwtAuthenticationFilter;
-import com.prgrms.artzip.common.jwt.JwtAuthenticationProvider;
 import com.prgrms.artzip.common.oauth.CustomOAuth2UserService;
 import com.prgrms.artzip.common.oauth.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.prgrms.artzip.common.oauth.OAuth2AuthenticationFailureHandler;
-import com.prgrms.artzip.common.util.JwtService;
 import com.prgrms.artzip.common.oauth.OAuth2AuthenticationSuccessHandler;
-import com.prgrms.artzip.user.service.UserService;
-import com.prgrms.artzip.user.service.UserUtilService;
+import java.io.PrintWriter;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -36,8 +32,6 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-
-import java.io.PrintWriter;
 
 @EnableWebSecurity
 @Configuration

--- a/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
@@ -45,7 +45,6 @@ import java.io.PrintWriter;
 public class WebSecurityConfig {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
-  private final JwtConfig jwtConfig;
 
   private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
 

--- a/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/prgrms/artzip/common/config/WebSecurityConfig.java
@@ -9,10 +9,12 @@ import com.prgrms.artzip.common.filter.ExceptionHandlerFilter;
 import com.prgrms.artzip.common.jwt.Jwt;
 import com.prgrms.artzip.common.jwt.JwtAuthenticationFilter;
 import com.prgrms.artzip.common.jwt.JwtAuthenticationProvider;
+import com.prgrms.artzip.common.oauth.OAuth2AuthenticationFailureHandler;
 import com.prgrms.artzip.common.util.JwtService;
 import com.prgrms.artzip.common.oauth.OAuth2AuthenticationSuccessHandler;
 import com.prgrms.artzip.user.service.UserService;
 import com.prgrms.artzip.user.service.UserUtilService;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -37,28 +39,19 @@ import java.io.PrintWriter;
 
 @EnableWebSecurity
 @Configuration
+@RequiredArgsConstructor
 public class WebSecurityConfig {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
   private final JwtConfig jwtConfig;
 
-  @Bean
-  @Qualifier("accessJwt")
-  public Jwt accessJwt() {
-    return new Jwt(
-        jwtConfig.getIssuer(),
-        jwtConfig.getClientSecret(),
-        jwtConfig.getAccessToken().getExpirySeconds());
-  }
+  private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
 
-  @Bean
-  @Qualifier("refreshJwt")
-  public Jwt refreshJwt() {
-    return new Jwt(
-        jwtConfig.getIssuer(),
-        jwtConfig.getClientSecret(),
-        jwtConfig.getRefreshToken().getExpirySeconds());
-  }
+  private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+
+  private final ExceptionHandlerFilter exceptionHandlerFilter;
+
+  private final ObjectMapper objectMapper;
 
   @Bean
   public PasswordEncoder passwordEncoder() {
@@ -103,19 +96,6 @@ public class WebSecurityConfig {
   }
 
   @Bean
-  public ExceptionHandlerFilter exceptionHandlerFilter(ObjectMapper objectMapper) {
-    return new ExceptionHandlerFilter(objectMapper);
-  }
-
-  @Bean
-  public OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler(JwtService jwtService, UserService userService, ObjectMapper objectMapper) {
-    return new OAuth2AuthenticationSuccessHandler(jwtService, userService, objectMapper);
-  }
-
-  public WebSecurityConfig(JwtConfig jwtConfig) {
-    this.jwtConfig = jwtConfig;
-  }
-
   public JwtAuthenticationFilter jwtAuthenticationFilter(JwtService jwtService,
       UserUtilService userUtilService) {
     return new JwtAuthenticationFilter(jwtConfig.getAccessToken().getHeader(), jwtService,
@@ -123,9 +103,8 @@ public class WebSecurityConfig {
   }
 
   @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http, JwtService jwtService,
-      UserUtilService userUtilService, ObjectMapper objectMapper,
-      ExceptionHandlerFilter exceptionHandlerFilter, OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler) throws Exception {
+  public SecurityFilterChain filterChain(HttpSecurity http,
+      JwtAuthenticationFilter jwtAuthenticationFilter, AccessDeniedHandler accessDeniedHandler, AuthenticationEntryPoint authenticationEntryPoint) throws Exception {
     http
         .cors()
         .and()
@@ -138,7 +117,8 @@ public class WebSecurityConfig {
             "/api/v1/exhibitions/**/likes",
             "api/v1/users/logout").hasAnyAuthority(USER.name(), ADMIN.name())
         .antMatchers(HttpMethod.POST,
-            "/api/v1/reviews", "/api/v1/comments/**", "/api/v1/reviews/**/comments").hasAnyAuthority(USER.name(), ADMIN.name())
+            "/api/v1/reviews", "/api/v1/comments/**", "/api/v1/reviews/**/comments")
+        .hasAnyAuthority(USER.name(), ADMIN.name())
         .antMatchers(HttpMethod.PATCH,
             "/api/v1/reviews/**", "/api/v1/reviews/**/like", "/api/v1/comments/**")
         .hasAnyAuthority(USER.name(), ADMIN.name())
@@ -151,12 +131,13 @@ public class WebSecurityConfig {
         .baseUri("/api/v1/users/oauth/login")
         .and()
         .successHandler(oAuth2AuthenticationSuccessHandler)
+        .failureHandler(oAuth2AuthenticationFailureHandler)
         .and()
         .exceptionHandling()
-        .accessDeniedHandler(accessDeniedHandler(objectMapper))
-        .authenticationEntryPoint(authenticationEntryPoint(objectMapper))
+        .accessDeniedHandler(accessDeniedHandler)
+        .authenticationEntryPoint(authenticationEntryPoint)
         .and()
-        .addFilterBefore(jwtAuthenticationFilter(jwtService, userUtilService),
+        .addFilterBefore(jwtAuthenticationFilter,
             UsernamePasswordAuthenticationFilter.class)
         .addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class);
     return http.build();

--- a/src/main/java/com/prgrms/artzip/common/error/exception/AuthErrorException.java
+++ b/src/main/java/com/prgrms/artzip/common/error/exception/AuthErrorException.java
@@ -2,9 +2,10 @@ package com.prgrms.artzip.common.error.exception;
 
 import com.prgrms.artzip.common.ErrorCode;
 import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
 
 @Getter
-public class AuthErrorException extends RuntimeException {
+public class AuthErrorException extends AuthenticationException {
 
   private final ErrorCode errorCode;
 

--- a/src/main/java/com/prgrms/artzip/common/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/prgrms/artzip/common/filter/ExceptionHandlerFilter.java
@@ -8,6 +8,7 @@ import com.prgrms.artzip.common.error.exception.AuthErrorException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -17,6 +18,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+@Component
 @RequiredArgsConstructor
 public class ExceptionHandlerFilter extends OncePerRequestFilter {
 

--- a/src/main/java/com/prgrms/artzip/common/oauth/AuthProvider.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/AuthProvider.java
@@ -1,0 +1,7 @@
+package com.prgrms.artzip.common.oauth;
+
+public enum AuthProvider {
+  kakao,
+  google,
+  naver
+}

--- a/src/main/java/com/prgrms/artzip/common/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,70 @@
+package com.prgrms.artzip.common.oauth;
+
+import static com.prgrms.artzip.common.ErrorCode.ROLE_NOT_FOUND;
+import static org.springframework.util.StringUtils.*;
+
+import com.prgrms.artzip.common.Authority;
+import com.prgrms.artzip.common.ErrorCode;
+import com.prgrms.artzip.common.error.exception.AuthErrorException;
+import com.prgrms.artzip.common.error.exception.NotFoundException;
+import com.prgrms.artzip.common.oauth.dto.OAuth2UserInfo;
+import com.prgrms.artzip.common.oauth.dto.OAuth2UserInfoFactory;
+import com.prgrms.artzip.user.domain.OAuthUser;
+import com.prgrms.artzip.user.domain.Role;
+import com.prgrms.artzip.user.domain.repository.RoleRepository;
+import com.prgrms.artzip.user.domain.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+  private final UserRepository userRepository;
+
+  private final RoleRepository roleRepository;
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest) throws OAuth2AuthenticationException {
+    OAuth2User oAuth2User = super.loadUser(oAuth2UserRequest);
+    try {
+      return processOAuth2User(oAuth2UserRequest, oAuth2User);
+    } catch (AuthErrorException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      // Throwing an instance of AuthenticationException will trigger the OAuth2AuthenticationFailureHandler
+      throw new InternalAuthenticationServiceException(ex.getMessage(), ex.getCause());
+    }
+  }
+
+  private OAuth2User processOAuth2User(OAuth2UserRequest oAuth2UserRequest, OAuth2User oAuth2User) {
+    OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(oAuth2UserRequest.getClientRegistration().getRegistrationId(), oAuth2User.getAttributes());
+    if(!hasText(oAuth2UserInfo.getEmail())) {
+      throw new AuthErrorException(ErrorCode.OAUTH_EMAIL_REQUIRED);
+    }
+    AuthProvider provider = AuthProvider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId().toLowerCase());
+    OAuthUser oAuthUser = userRepository.findByProviderAndProviderId(provider, oAuth2User.getName())
+        .orElseGet(() -> oauthSignUp(oAuth2UserRequest, oAuth2UserInfo));
+    return new OAuthUserPrincipal(oAuthUser, oAuth2User.getAttributes());
+  }
+
+  private OAuthUser oauthSignUp(OAuth2UserRequest oAuth2UserRequest, OAuth2UserInfo oAuth2UserInfo) {
+    Role userRole = roleRepository.findByAuthority(Authority.USER)
+        .orElseThrow(() -> new NotFoundException(ROLE_NOT_FOUND));
+    OAuthUser oAuthUser = OAuthUser.builder()
+        .email(oAuth2UserInfo.getEmail())
+        .nickname(oAuth2UserInfo.getNickName())
+        .provider(AuthProvider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId().toLowerCase()))
+        .providerId(oAuth2UserInfo.getId())
+        .roles(List.of(userRole))
+        .build();
+    if(hasText(oAuth2UserInfo.getImageUrl())) oAuthUser.setProfileImage(oAuth2UserInfo.getImageUrl());
+    return userRepository.save(oAuthUser);
+  }
+
+}

--- a/src/main/java/com/prgrms/artzip/common/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -5,7 +5,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 
 import static org.springframework.util.StringUtils.*;

--- a/src/main/java/com/prgrms/artzip/common/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,50 @@
+package com.prgrms.artzip.common.oauth;
+
+import com.prgrms.artzip.common.util.CookieUtil;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
+
+import static org.springframework.util.StringUtils.*;
+
+@Repository
+public class HttpCookieOAuth2AuthorizationRequestRepository implements
+    AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+  public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+  public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+  private static final int cookieExpireSeconds = 180;
+
+  @Override
+  public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+    return CookieUtil.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+        .map(cookie -> CookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class))
+        .orElse(null);
+  }
+
+  @Override
+  public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+    if (authorizationRequest == null) {
+      CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+      CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+      return;
+    }
+    CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtil.serialize(authorizationRequest), cookieExpireSeconds);
+    String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+    if (hasText(redirectUriAfterLogin)) {
+      CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+    }
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+    return this.loadAuthorizationRequest(request);
+  }
+
+  public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+    CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+    CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+  }
+}

--- a/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationFailureHandler.java
@@ -1,9 +1,36 @@
 package com.prgrms.artzip.common.oauth;
 
+import static com.prgrms.artzip.common.oauth.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
+import com.prgrms.artzip.common.util.CookieUtil;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
+@RequiredArgsConstructor
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+  private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+    String targetUrl = CookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+        .map(Cookie::getValue)
+        .orElse(("/"));
+
+    targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
+        .queryParam("error", exception.getMessage())
+        .build().toUriString();
+
+    httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+    getRedirectStrategy().sendRedirect(request, response, targetUrl);
+  }
 }

--- a/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationFailureHandler.java
@@ -1,5 +1,9 @@
 package com.prgrms.artzip.common.oauth;
 
-public class OAuth2AuthenticationFailureHandler {
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
 }

--- a/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationFailureHandler.java
@@ -4,7 +4,6 @@ import static com.prgrms.artzip.common.oauth.HttpCookieOAuth2AuthorizationReques
 
 import com.prgrms.artzip.common.util.CookieUtil;
 import java.io.IOException;
-import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -1,77 +1,79 @@
 package com.prgrms.artzip.common.oauth;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static com.prgrms.artzip.common.oauth.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
 import com.prgrms.artzip.common.util.CookieUtil;
 import com.prgrms.artzip.common.util.JwtService;
 import com.prgrms.artzip.user.domain.Role;
 import com.prgrms.artzip.user.domain.User;
-import com.prgrms.artzip.user.service.UserService;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import static org.springframework.util.StringUtils.*;
 
 @Component
 @RequiredArgsConstructor
 public class OAuth2AuthenticationSuccessHandler extends
     SavedRequestAwareAuthenticationSuccessHandler {
-  private final Logger log = LoggerFactory.getLogger(getClass());
 
+  private final Logger log = LoggerFactory.getLogger(getClass());
   private final JwtService jwtService;
 
-  //private final UserService userService;
-
-  private static final String REFRESH_TOKEN = "refreshToken";
-
+  private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
   private static final String FRONT_PROD_URL = "https://artzip.shop/oauth/callback";
-  private static final String FRONT_TEST_URL = "http://localhost:3000/oauth/callback";
 
   @Override
-  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws ServletException, IOException {
-    if (authentication instanceof OAuth2AuthenticationToken oauth2Token) {
-      OAuth2User principal = oauth2Token.getPrincipal();
-      String registrationId = oauth2Token.getAuthorizedClientRegistrationId();
-
-      User user = processUserOAuth2UserJoin(principal, registrationId);
-
-      response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-
-      String targetUri = determineTargetUrl(request, response, FRONT_PROD_URL, user);
-      getRedirectStrategy().sendRedirect(request, response, targetUri);
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws ServletException, IOException {
+    if (authentication.getPrincipal() instanceof OAuthUserPrincipal principal) {
+      String targetUrl = determineTargetUrl(request, response, principal.getOAuthUser());
+      if (response.isCommitted()) {
+        log.debug("Response has already been committed. Unable to redirect to " + targetUrl);
+        return;
+      }
+      clearAuthenticationAttributes(request, response);
+      getRedirectStrategy().sendRedirect(request, response, targetUrl);
     } else {
       super.onAuthenticationSuccess(request, response, authentication);
     }
   }
 
-  private String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, String baseUrl, User user) {
 
+  private String determineTargetUrl(HttpServletRequest request, HttpServletResponse response,
+      User user) {
+
+    Optional<String> redirectUri = CookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+        .map(Cookie::getValue);
+
+    // TODO: 프론트에서 보낸 redirect url이 올바른 파라미터인가 validation
+
+    String targetUri = redirectUri.orElse(FRONT_PROD_URL);
     String accessToken = generateAccessToken(user);
     String refreshToken = generateRefreshToken(user);
 
-    return UriComponentsBuilder.fromUriString(baseUrl)
+    return UriComponentsBuilder.fromUriString(targetUri)
         .queryParam("refreshToken", refreshToken)
         .queryParam("accessToken", accessToken)
         .queryParam("userId", user.getId())
         .build().toUriString();
   }
 
-  private User processUserOAuth2UserJoin(OAuth2User oAuth2User, String registrationId) {
-    return null;
+  protected void clearAuthenticationAttributes(HttpServletRequest request,
+      HttpServletResponse response) {
+    super.clearAuthenticationAttributes(request);
+    httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request,
+        response);
   }
 
   private String generateAccessToken(User user) {

--- a/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -20,10 +20,12 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.springframework.util.StringUtils.*;
 
+@Component
 @RequiredArgsConstructor
 public class OAuth2AuthenticationSuccessHandler extends
     SavedRequestAwareAuthenticationSuccessHandler {
@@ -31,9 +33,8 @@ public class OAuth2AuthenticationSuccessHandler extends
 
   private final JwtService jwtService;
 
-  private final UserService userService;
+  //private final UserService userService;
 
-  private final ObjectMapper objectMapper;
   private static final String REFRESH_TOKEN = "refreshToken";
 
   private static final String FRONT_PROD_URL = "https://artzip.shop/oauth/callback";
@@ -70,7 +71,7 @@ public class OAuth2AuthenticationSuccessHandler extends
   }
 
   private User processUserOAuth2UserJoin(OAuth2User oAuth2User, String registrationId) {
-    return userService.oauthSignUp(oAuth2User, registrationId);
+    return null;
   }
 
   private String generateAccessToken(User user) {

--- a/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -50,7 +50,7 @@ public class OAuth2AuthenticationSuccessHandler extends
       response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
-      String targetUri = determineTargetUrl(request, response, FRONT_TEST_URL, user);
+      String targetUri = determineTargetUrl(request, response, FRONT_PROD_URL, user);
       getRedirectStrategy().sendRedirect(request, response, targetUri);
     } else {
       super.onAuthenticationSuccess(request, response, authentication);

--- a/src/main/java/com/prgrms/artzip/common/oauth/OAuthUserPrincipal.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/OAuthUserPrincipal.java
@@ -2,7 +2,6 @@ package com.prgrms.artzip.common.oauth;
 
 import com.prgrms.artzip.user.domain.OAuthUser;
 import com.prgrms.artzip.user.domain.Role;
-import com.prgrms.artzip.user.domain.User;
 import java.util.Collection;
 import java.util.Map;
 import lombok.Getter;

--- a/src/main/java/com/prgrms/artzip/common/oauth/OAuthUserPrincipal.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/OAuthUserPrincipal.java
@@ -1,0 +1,39 @@
+package com.prgrms.artzip.common.oauth;
+
+import com.prgrms.artzip.user.domain.OAuthUser;
+import com.prgrms.artzip.user.domain.Role;
+import com.prgrms.artzip.user.domain.User;
+import java.util.Collection;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@Getter
+@RequiredArgsConstructor
+public class OAuthUserPrincipal implements OAuth2User {
+
+  private final OAuthUser oAuthUser;
+  private final Map<String, Object> attributes;
+
+  @Override
+  public <A> A getAttribute(String name) {
+    return OAuth2User.super.getAttribute(name);
+  }
+
+  @Override
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return oAuthUser.getRoles().stream().map(Role::toGrantedAuthority).toList();
+  }
+
+  @Override
+  public String getName() {
+    return oAuthUser.getProviderId();
+  }
+}

--- a/src/main/java/com/prgrms/artzip/common/oauth/dto/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/dto/KakaoOAuth2UserInfo.java
@@ -1,0 +1,32 @@
+package com.prgrms.artzip.common.oauth.dto;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo{
+
+  private Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+  private Map<String, Object> accountInfo = (Map<String, Object>) attributes.get("kakao_account");
+  public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+    super(attributes);
+  }
+
+  @Override
+  public String getId() {
+    return (String) attributes.get("id");
+  }
+
+  @Override
+  public String getNickName() {
+    return (String) properties.get("nickname");
+  }
+
+  @Override
+  public String getEmail() {
+    return (String) accountInfo.get("email");
+  }
+
+  @Override
+  public String getImageUrl() {
+    return (String) properties.get("profile_image");
+  }
+}

--- a/src/main/java/com/prgrms/artzip/common/oauth/dto/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/dto/KakaoOAuth2UserInfo.java
@@ -4,8 +4,8 @@ import java.util.Map;
 
 public class KakaoOAuth2UserInfo extends OAuth2UserInfo{
 
-  private Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
-  private Map<String, Object> accountInfo = (Map<String, Object>) attributes.get("kakao_account");
+  private final Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+  private final Map<String, Object> accountInfo = (Map<String, Object>) attributes.get("kakao_account");
   public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
     super(attributes);
   }

--- a/src/main/java/com/prgrms/artzip/common/oauth/dto/OAuth2UserInfo.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/dto/OAuth2UserInfo.java
@@ -1,0 +1,23 @@
+package com.prgrms.artzip.common.oauth.dto;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+  protected Map<String, Object> attributes;
+
+  public OAuth2UserInfo(Map<String, Object> attributes) {
+    this.attributes = attributes;
+  }
+
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+
+  public abstract String getId();
+
+  public abstract String getNickName();
+
+  public abstract String getEmail();
+
+  public abstract String getImageUrl();
+}

--- a/src/main/java/com/prgrms/artzip/common/oauth/dto/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/prgrms/artzip/common/oauth/dto/OAuth2UserInfoFactory.java
@@ -1,0 +1,17 @@
+package com.prgrms.artzip.common.oauth.dto;
+
+import com.prgrms.artzip.common.ErrorCode;
+import com.prgrms.artzip.common.error.exception.AuthErrorException;
+import com.prgrms.artzip.common.oauth.AuthProvider;
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+
+  public static OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
+    if (registrationId.equalsIgnoreCase(AuthProvider.kakao.toString())) {
+      return new KakaoOAuth2UserInfo(attributes);
+    } else {
+      throw new AuthErrorException(ErrorCode.OAUTH_PROVIDER_UNSUPPORTED);
+    }
+  }
+}

--- a/src/main/java/com/prgrms/artzip/common/util/CookieUtil.java
+++ b/src/main/java/com/prgrms/artzip/common/util/CookieUtil.java
@@ -1,9 +1,12 @@
 package com.prgrms.artzip.common.util;
 
+import java.util.Base64;
 import java.util.Optional;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.springframework.util.SerializationUtils;
+
 import static java.util.Objects.*;
 
 public class CookieUtil {
@@ -42,6 +45,19 @@ public class CookieUtil {
         }
       }
     }
+  }
+
+  public static String serialize(Object obj) {
+    return Base64.getUrlEncoder()
+        .encodeToString(SerializationUtils.serialize(obj));
+  }
+
+  public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+    return cls.cast(
+        SerializationUtils.deserialize(
+            Base64.getUrlDecoder().decode(cookie.getValue())
+        )
+    );
   }
 
 }

--- a/src/main/java/com/prgrms/artzip/common/util/JwtService.java
+++ b/src/main/java/com/prgrms/artzip/common/util/JwtService.java
@@ -55,7 +55,7 @@ public class JwtService {
   public String createRefreshToken(String email) {
     String refreshToken = refreshJwt.sign(new RefreshClaim(email));
     redisService.setValues(email, refreshToken, Duration.ofSeconds(
-        jwtConfig.getRefreshToken().getExpirySeconds()));
+        refreshJwt.getExpirySeconds()));
     return refreshToken;
   }
 

--- a/src/main/java/com/prgrms/artzip/user/domain/OAuthUser.java
+++ b/src/main/java/com/prgrms/artzip/user/domain/OAuthUser.java
@@ -1,7 +1,11 @@
 package com.prgrms.artzip.user.domain;
 
+import com.prgrms.artzip.common.oauth.AuthProvider;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
@@ -12,16 +16,18 @@ import java.util.List;
 @Entity
 @DiscriminatorValue("OAUTH")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class OAuthUser extends User {
 
+  @Enumerated(EnumType.STRING)
   @Column(name = "provider")
-  private String provider;
+  private AuthProvider provider;
 
   @Column(name = "provider_id")
   private String providerId;
 
   @Builder
-  public OAuthUser(String email, String nickname, String provider, String providerId,
+  public OAuthUser(String email, String nickname, AuthProvider provider, String providerId,
       List<Role> roles) {
     super(email, nickname, roles);
     this.provider = provider;

--- a/src/main/java/com/prgrms/artzip/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/prgrms/artzip/user/domain/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.prgrms.artzip.user.domain.repository;
 
+import com.prgrms.artzip.common.oauth.AuthProvider;
 import com.prgrms.artzip.user.domain.OAuthUser;
 import com.prgrms.artzip.user.domain.User;
 import io.lettuce.core.dynamic.annotation.Param;
@@ -27,5 +28,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNicknameExceptId(@Param("userId") Long userId, @Param("nickname") String nickname);
 
     @Query("select ou from OAuthUser ou join fetch ou.roles r where ou.provider = :provider and ou.providerId = :providerId")
-    Optional<OAuthUser> findByProviderAndProviderId(@Param("provider") String provider, @Param("providerId") String providerId);
+    Optional<OAuthUser> findByProviderAndProviderId(@Param("provider") AuthProvider provider, @Param("providerId") String providerId);
 }

--- a/src/main/java/com/prgrms/artzip/user/service/UserService.java
+++ b/src/main/java/com/prgrms/artzip/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.prgrms.artzip.common.ErrorCode;
 import com.prgrms.artzip.common.error.exception.AlreadyExistsException;
 import com.prgrms.artzip.common.error.exception.InvalidRequestException;
 import com.prgrms.artzip.common.error.exception.NotFoundException;
+import com.prgrms.artzip.common.oauth.AuthProvider;
 import com.prgrms.artzip.common.util.AmazonS3Remover;
 import com.prgrms.artzip.common.util.AmazonS3Uploader;
 import com.prgrms.artzip.user.domain.LocalUser;
@@ -83,39 +84,39 @@ public class UserService {
     return userRepository.save(newUser);
   }
 
-  @Transactional
-  public User oauthSignUp(OAuth2User oauth2User, String provider) {
-    if (isNull(oauth2User)) throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
-    if (!hasText(provider)) throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
-
-    String providerId = oauth2User.getName();
-    return userRepository.findByProviderAndProviderId(provider, providerId)
-        .orElseGet(() -> {
-          Map<String, Object> attributes = oauth2User.getAttributes();
-          Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
-          Map<String, Object> accountInfo = (Map<String, Object>) attributes.get("kakao_account");
-
-          if (isNull(properties)) throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
-          if (isNull(accountInfo)) throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
-
-          // TODO: attributes에서 user에 필요한 정보 뽑아내는 부분 vendor에 따른 추상화 리팩토링 필요
-          String email = (String) accountInfo.get("email");
-          String nickname = (String) properties.get("nickname");
-          String profileImage = (String) properties.get("profile_image");
-          Role userRole = roleRepository.findByAuthority(Authority.USER)
-              .orElseThrow(() -> new NotFoundException(ROLE_NOT_FOUND));
-
-          OAuthUser user = OAuthUser.builder()
-              .email(email)
-              .nickname(nickname)
-              .provider(provider)
-              .providerId(providerId)
-              .roles(List.of(userRole))
-              .build();
-          if (hasText(profileImage)) user.setProfileImage(profileImage);
-          return userRepository.save(user);
-        });
-  }
+//  @Transactional
+//  public User oauthSignUp(OAuth2User oauth2User, String provider) {
+//    if (isNull(oauth2User)) throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
+//    if (!hasText(provider)) throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
+//
+//    String providerId = oauth2User.getName();
+//    return userRepository.findByProviderAndProviderId(provider, providerId)
+//        .orElseGet(() -> {
+//          Map<String, Object> attributes = oauth2User.getAttributes();
+//          Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+//          Map<String, Object> accountInfo = (Map<String, Object>) attributes.get("kakao_account");
+//
+//          if (isNull(properties)) throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
+//          if (isNull(accountInfo)) throw new InvalidRequestException(MISSING_REQUEST_PARAMETER);
+//
+//          // TODO: attributes에서 user에 필요한 정보 뽑아내는 부분 vendor에 따른 추상화 리팩토링 필요
+//          String email = (String) accountInfo.get("email");
+//          String nickname = (String) properties.get("nickname");
+//          String profileImage = (String) properties.get("profile_image");
+//          Role userRole = roleRepository.findByAuthority(Authority.USER)
+//              .orElseThrow(() -> new NotFoundException(ROLE_NOT_FOUND));
+//
+//          OAuthUser user = OAuthUser.builder()
+//              .email(email)
+//              .nickname(nickname)
+//              .provider(AuthProvider.valueOf(provider.toLowerCase()))
+//              .providerId(providerId)
+//              .roles(List.of(userRole))
+//              .build();
+//          if (hasText(profileImage)) user.setProfileImage(profileImage);
+//          return userRepository.save(user);
+//        });
+//  }
 
   @Transactional
   public UserUpdateResponse updateUserInfo(User user, UserUpdateRequest request, MultipartFile file) {

--- a/src/test/java/com/prgrms/artzip/user/domain/repository/UserRepositoryTest.java
+++ b/src/test/java/com/prgrms/artzip/user/domain/repository/UserRepositoryTest.java
@@ -4,6 +4,7 @@ import com.prgrms.artzip.QueryDslTestConfig;
 import com.prgrms.artzip.common.Authority;
 import com.prgrms.artzip.common.ErrorCode;
 import com.prgrms.artzip.common.error.exception.NotFoundException;
+import com.prgrms.artzip.common.oauth.AuthProvider;
 import com.prgrms.artzip.user.domain.LocalUser;
 import com.prgrms.artzip.user.domain.OAuthUser;
 import com.prgrms.artzip.user.domain.Role;
@@ -59,7 +60,7 @@ class UserRepositoryTest {
         .email("test2@gmail.com")
         .nickname("공공2")
         .roles(List.of(userRole, adminRole))
-        .provider("kakao")
+        .provider(AuthProvider.kakao)
         .providerId("kakaoId")
         .build();
 

--- a/src/test/java/com/prgrms/artzip/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/artzip/user/service/UserServiceTest.java
@@ -1,24 +1,13 @@
 package com.prgrms.artzip.user.service;
 
-import static com.prgrms.artzip.common.ErrorCode.INVALID_INPUT_VALUE;
-import static com.prgrms.artzip.common.ErrorCode.LOGIN_PARAM_REQUIRED;
-import static com.prgrms.artzip.common.ErrorCode.NICKNAME_ALREADY_EXISTS;
-import static com.prgrms.artzip.common.ErrorCode.ROLE_NOT_FOUND;
-import static com.prgrms.artzip.common.ErrorCode.USER_ALREADY_EXISTS;
-import static com.prgrms.artzip.common.ErrorCode.USER_NOT_FOUND;
-import static com.prgrms.artzip.common.ErrorCode.USER_PROFILE_NOT_MATCHED;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static com.prgrms.artzip.common.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import com.prgrms.artzip.common.Authority;
 import com.prgrms.artzip.common.error.exception.AlreadyExistsException;
 import com.prgrms.artzip.common.error.exception.InvalidRequestException;
 import com.prgrms.artzip.common.error.exception.NotFoundException;
-import com.prgrms.artzip.common.oauth.AuthProvider;
 import com.prgrms.artzip.common.util.AmazonS3Remover;
 import com.prgrms.artzip.common.util.AmazonS3Uploader;
 import com.prgrms.artzip.user.domain.LocalUser;
@@ -31,9 +20,7 @@ import com.prgrms.artzip.user.dto.request.UserLocalLoginRequest;
 import com.prgrms.artzip.user.dto.request.UserSignUpRequest;
 import com.prgrms.artzip.user.dto.request.UserUpdateRequest;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -48,11 +35,8 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/prgrms/artzip/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/artzip/user/service/UserServiceTest.java
@@ -18,6 +18,7 @@ import com.prgrms.artzip.common.Authority;
 import com.prgrms.artzip.common.error.exception.AlreadyExistsException;
 import com.prgrms.artzip.common.error.exception.InvalidRequestException;
 import com.prgrms.artzip.common.error.exception.NotFoundException;
+import com.prgrms.artzip.common.oauth.AuthProvider;
 import com.prgrms.artzip.common.util.AmazonS3Remover;
 import com.prgrms.artzip.common.util.AmazonS3Uploader;
 import com.prgrms.artzip.user.domain.LocalUser;
@@ -396,36 +397,6 @@ class UserServiceTest {
         .isInstanceOf(InvalidRequestException.class)
         .hasMessage(INVALID_INPUT_VALUE.getMessage());
   }
-
-  @Test
-  @DisplayName("소셜로그인 회원가입 테스트")
-  void testOAuthSignUp() {
-    //given
-    Map<String, Object> attributes = new HashMap<>();
-    Map<String, Object> properties = Map.of(
-        "nickname", "김승은",
-        "profile_image", "testUrl"
-    );
-    Map<String, Object> accountInfo = Map.of(
-        "email", "julie0005@ajou.ac.kr"
-    );
-    attributes.put("properties", properties);
-    attributes.put("kakao_account", accountInfo);
-    attributes.put("id", "12345678");
-    String provider = "kakao";
-    OAuth2User oAuth2User = new DefaultOAuth2User(List.of(Role.toGrantedAuthority(new Role(Authority.USER))), attributes, "id");
-    when(userRepository.findByProviderAndProviderId(eq(provider), eq(oAuth2User.getName()))).thenReturn(Optional.empty());
-    when(roleRepository.findByAuthority(Authority.USER)).thenReturn(Optional.of(userRole));
-
-    // when
-    userService.oauthSignUp(oAuth2User, provider);
-
-    // then
-    verify(userRepository).findByProviderAndProviderId(provider, oAuth2User.getName());
-    verify(roleRepository).findByAuthority(Authority.USER);
-    verify(userRepository).save(any());
-  }
-
 
   private static Stream<Arguments> errorLoginParameter() {
     return Stream.of(


### PR DESCRIPTION
## 구현 내용
### 소셜로그인 vendor 확장할 수 있도록 변경
* OAuth2UserInfo 와 OAuth2UserInfoFactory 클래스 생성
    * 카카오, 구글, 네이버 등에서 받아온 유저 정보의 object key, value가 각각 다르므로 팩토리를 통해 추상화
### redirect_uri를 통해 프론트에서 인증 완료 후 로그인 페이지 지정할 수 있게 구현
* HttpCookieOAuth2AuthorizationRequestRepository를 통해 code grant 과정 시작 전에 request를 save하고, 인증 성공 시, save한 request 꺼내서 redirect
### OAuth2AuthenticationFailureHandler 구현
* 인증 실패 시 failureHandler를 통해 예외 처리
### CORS 도메인 설정
* localhost:3000, 프론트 배포 링크로 설정 후 와일드 카드 제거

## TODO
* jwt service test 작성
* vendor 확장
* CustomOAuth2UserService test 작성
    * UserService에서 oauthSignUp이 CustomOAuth2UserService로 이동됨에 따라 테스트 코드도 삭제했습니다.
    * 곧 추가하겠습니다.