### PR TITLE
review repository 리팩토링

### DIFF
--- a/src/main/java/com/prgrms/artzip/common/ErrorCode.java
+++ b/src/main/java/com/prgrms/artzip/common/ErrorCode.java
@@ -98,7 +98,8 @@ public enum ErrorCode {
   INVALID_REVIEW_PHOTO_COUNT(400, "R008", "리뷰 사진은 최대 9개입니다."),
   REVIEW_NOT_FOUND(400, "R009", "존재하지 않는 리뷰입니다."),
   REVIEW_PHOTO_NOT_FOUND(400, "R010", "존재하지 않는 리뷰 사진입니다."),
-  NO_PERMISSION_TO_UPDATE_REVIEW(404, "R011", "해당 리뷰를 수정할 수 없습니다.");
+  NO_PERMISSION_TO_UPDATE_REVIEW(404, "R011", "해당 리뷰를 수정할 수 없습니다."),
+  INVALID_REVIEW_SORT_TYPE(400, "R012", "유효하지 않은 후기 정렬 조건입니다.");
 
 
   private final int status;

--- a/src/main/java/com/prgrms/artzip/common/util/QueryDslCustomUtils.java
+++ b/src/main/java/com/prgrms/artzip/common/util/QueryDslCustomUtils.java
@@ -1,6 +1,7 @@
 package com.prgrms.artzip.common.util;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import java.util.function.Supplier;
@@ -20,5 +21,19 @@ public class QueryDslCustomUtils {
     } catch (IllegalArgumentException e) {
       return new BooleanBuilder();
     }
+  }
+
+  /**
+   * If all conditions are null,
+   * returns BooleanExpression that is always false
+   * @param conditions
+   * @return BooleanExpression
+   */
+  public static Predicate nullSafeConditions(Predicate... conditions) {
+    BooleanBuilder booleanBuilder = new BooleanBuilder();
+    for (Predicate condition : conditions) {
+      booleanBuilder.and(condition);
+    }
+    return alwaysFalse().or(booleanBuilder);
   }
 }

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepository.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface ReviewCustomRepository {
 
-  Optional<ReviewWithLikeAndCommentCount> findReviewByReviewIdAndUserId(Long reviewId, Long userId);
+  Optional<ReviewWithLikeAndCommentCount> findReviewByReviewId(Long reviewId, Long userId);
 
   Page<ReviewWithLikeAndCommentCount> findReviewsByExhibitionIdAndUserId(
       Long exhibitionId, Long userId, Pageable pageable);

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepository.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepository.java
@@ -1,14 +1,13 @@
 package com.prgrms.artzip.review.domain.repository;
 
 import com.prgrms.artzip.review.dto.projection.ReviewWithLikeAndCommentCount;
-import com.prgrms.artzip.review.dto.projection.ReviewWithLikeData;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ReviewCustomRepository {
 
-  Optional<ReviewWithLikeAndCommentCount> findByReviewIdAndUserId(Long reviewId, Long userId);
+  Optional<ReviewWithLikeAndCommentCount> findReviewByReviewIdAndUserId(Long reviewId, Long userId);
 
   Page<ReviewWithLikeAndCommentCount> findReviewsByExhibitionIdAndUserId(
       Long exhibitionId, Long userId, Pageable pageable);

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepository.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepository.java
@@ -9,7 +9,7 @@ public interface ReviewCustomRepository {
 
   Optional<ReviewWithLikeAndCommentCount> findReviewByReviewId(Long reviewId, Long userId);
 
-  Page<ReviewWithLikeAndCommentCount> findReviewsByExhibitionIdAndUserId(
+  Page<ReviewWithLikeAndCommentCount> findReviews(
       Long exhibitionId, Long userId, Pageable pageable);
 
   Page<ReviewWithLikeAndCommentCount> findMyLikesReviews(

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepository.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepository.java
@@ -7,14 +7,41 @@ import org.springframework.data.domain.Pageable;
 
 public interface ReviewCustomRepository {
 
+  /**
+   * Retrieves a review DTO by review id.
+   * @param reviewId must not be null
+   * @param userId id of the logged-in user
+   * @return the ReviewWithLikeAndCommentCount DTO
+   */
   Optional<ReviewWithLikeAndCommentCount> findReviewByReviewId(Long reviewId, Long userId);
 
+  /**
+   * returns all reviews(ReviewWithLikeAndCommentCount DTO) with the given parameters.
+   * @param exhibitionId
+   * @param userId id of the logged-in user
+   * @param pageable must not be null
+   * @return the list of ReviewWithLikeAndCommentCount DTO with pagination
+   */
   Page<ReviewWithLikeAndCommentCount> findReviews(
       Long exhibitionId, Long userId, Pageable pageable);
 
+  /**
+   * returns all reviews(ReviewWithLikeAndCommentCount DTO) with the given parameters.
+   * @param currentUserId id of the logged-in user
+   * @param targetUserId must not be null
+   * @param pageable must not be null
+   * @return the list of ReviewWithLikeAndCommentCount DTO with pagination
+   */
   Page<ReviewWithLikeAndCommentCount> findMyLikesReviews(
       Long currentUserId, Long targetUserId, Pageable pageable);
 
+  /**
+   * returns all reviews(ReviewWithLikeAndCommentCount DTO) with the given parameters.
+   * @param currentUserId id of the logged-in user
+   * @param targetUserId must not be null
+   * @param pageable must not be null
+   * @return the list of ReviewWithLikeAndCommentCount DTO with pagination
+   */
   Page<ReviewWithLikeAndCommentCount> findMyReviews(
       Long currentUserId, Long targetUserId, Pageable pageable);
 }

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
@@ -40,7 +40,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
   }
 
   @Override
-  public Optional<ReviewWithLikeAndCommentCount> findByReviewIdAndUserId(
+  public Optional<ReviewWithLikeAndCommentCount> findReviewByReviewIdAndUserId(
       Long reviewId, Long userId) {
 
     ReviewWithLikeAndCommentCount data =

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
@@ -1,8 +1,8 @@
 package com.prgrms.artzip.review.domain.repository;
 
 import static com.prgrms.artzip.comment.domain.QComment.comment;
-import static com.prgrms.artzip.common.util.QueryDslCustomUtils.alwaysFalse;
 import static com.prgrms.artzip.common.util.QueryDslCustomUtils.nullSafeBooleanBuilder;
+import static com.prgrms.artzip.common.util.QueryDslCustomUtils.nullSafeConditions;
 import static com.prgrms.artzip.review.domain.QReview.review;
 import static com.prgrms.artzip.review.domain.QReviewLike.reviewLike;
 
@@ -141,7 +141,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
                 review.createdAt,
                 review.updatedAt,
                 new CaseBuilder()
-                    .when(alwaysFalse().or(reviewLikeUserIdEq(userId)))
+                    .when(nullSafeConditions(reviewLikeUserIdEq(userId)))
                     .then(true)
                     .otherwise(false).as("isLiked"),
                 review.isPublic,
@@ -150,7 +150,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
             ))
         .from(review)
         .leftJoin(reviewLikeToGetIsLiked).on(reviewLikeToGetIsLiked.review.eq(review),
-            alwaysFalse().or(reviewLikeUserIdEq(userId)))
+            nullSafeConditions(reviewLikeUserIdEq(userId)))
         .leftJoin(reviewLike).on(review.id.eq(reviewLike.review.id))
         .leftJoin(comment).on(review.id.eq(comment.review.id), comment.isDeleted.isFalse());
   }

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
@@ -55,7 +55,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
   }
 
   @Override
-  public Page<ReviewWithLikeAndCommentCount> findReviewsByExhibitionIdAndUserId(
+  public Page<ReviewWithLikeAndCommentCount> findReviews(
       Long exhibitionId, Long userId, Pageable pageable) {
 
     List<ReviewWithLikeAndCommentCount> content =

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
@@ -45,7 +45,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
 
     ReviewWithLikeAndCommentCount data =
         selectReviewWithLikeAndCommentCount(userId)
-            .where(review.isDeleted.eq(false),
+            .where(review.isDeleted.isFalse(),
                 review.id.eq(reviewId),
                 filterIsNotPublic(userId))
             .groupBy(review.id)
@@ -60,8 +60,8 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
 
     List<ReviewWithLikeAndCommentCount> content =
         selectReviewWithLikeAndCommentCount(userId)
-            .where(review.isDeleted.eq(false),
-                review.isPublic.eq(true),
+            .where(review.isDeleted.isFalse(),
+                review.isPublic.isTrue(),
                 reviewExhibitionIdEq(exhibitionId))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
@@ -72,8 +72,8 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
     JPAQuery<Long> countQuery = queryFactory
         .select(review.count())
         .from(review)
-        .where(review.isDeleted.eq(false),
-            review.isPublic.eq(true),
+        .where(review.isDeleted.isFalse(),
+            review.isPublic.isTrue(),
             reviewExhibitionIdEq(exhibitionId));
 
     return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
@@ -87,8 +87,8 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
         selectReviewWithLikeAndCommentCount(currentUserId)
             .leftJoin(reviewLikeToFilterTargetUser)
             .on(review.id.eq(reviewLikeToFilterTargetUser.review.id))
-            .where(review.isDeleted.eq(false),
-                review.isPublic.eq(true),
+            .where(review.isDeleted.isFalse(),
+                review.isPublic.isTrue(),
                 reviewLikeTargetUserIdEq(targetUserId))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
@@ -99,8 +99,8 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
     JPAQuery<Long> countQuery = queryFactory
         .select(review.count())
         .from(review)
-        .where(review.isDeleted.eq(false),
-            review.isPublic.eq(true),
+        .where(review.isDeleted.isFalse(),
+            review.isPublic.isTrue(),
             reviewLikeTargetUserIdEq(targetUserId));
 
     return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
@@ -173,9 +173,9 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
 
   private BooleanExpression filterIsNotPublic(Long userId) {
     if (Objects.isNull(userId)) {
-      return review.isPublic.eq(true);
+      return review.isPublic.isTrue();
     } else {
-      return review.user.id.eq(userId).or(review.user.id.ne(userId).and(review.isPublic.eq(true)));
+      return review.user.id.eq(userId).or(review.user.id.ne(userId).and(review.isPublic.isTrue()));
     }
   }
 

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
@@ -236,8 +236,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
     }
 
     return pageable.getSort().stream()
-        .filter(order -> ReviewSortType.getReviewSortType(order.getProperty()).isPresent())
-        .map(order -> ReviewSortType.getReviewSortType(order.getProperty()).get()
+        .map(order -> ReviewSortType.getReviewSortType(order.getProperty())
             .getOrderSpecifier(order.getDirection().isAscending() ? Order.ASC : Order.DESC))
         .collect(Collectors.toList());
   }

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
@@ -25,8 +25,13 @@ import javax.persistence.EntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.Assert;
 
 public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
+
+  private static final String REVIEW_ID_MUST_NOT_BE_NULL = "The given review id must not be null!";
+  private static final String USER_ID_MUST_NOT_BE_NULL = "The given user id must not be null!";
+  private static final String PAGEABLE_MUST_NOT_BE_NULL = "The given pageable must not be null!";
 
   private final JPAQueryFactory queryFactory;
 
@@ -43,6 +48,8 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
   public Optional<ReviewWithLikeAndCommentCount> findReviewByReviewId(
       Long reviewId, Long userId) {
 
+    Assert.notNull(reviewId, REVIEW_ID_MUST_NOT_BE_NULL);
+
     ReviewWithLikeAndCommentCount data =
         selectReviewWithLikeAndCommentCount(userId)
             .where(review.isDeleted.isFalse(),
@@ -57,6 +64,8 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
   @Override
   public Page<ReviewWithLikeAndCommentCount> findReviews(
       Long exhibitionId, Long userId, Pageable pageable) {
+
+    Assert.notNull(pageable, PAGEABLE_MUST_NOT_BE_NULL);
 
     List<ReviewWithLikeAndCommentCount> content =
         selectReviewWithLikeAndCommentCount(userId)
@@ -82,6 +91,9 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
   @Override
   public Page<ReviewWithLikeAndCommentCount> findMyLikesReviews(
       Long currentUserId, Long targetUserId, Pageable pageable) {
+
+    Assert.notNull(targetUserId, USER_ID_MUST_NOT_BE_NULL);
+    Assert.notNull(pageable, PAGEABLE_MUST_NOT_BE_NULL);
 
     List<ReviewWithLikeAndCommentCount> content =
         selectReviewWithLikeAndCommentCount(currentUserId)
@@ -109,6 +121,9 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
   @Override
   public Page<ReviewWithLikeAndCommentCount> findMyReviews(
       Long currentUserId, Long targetUserId, Pageable pageable) {
+
+    Assert.notNull(targetUserId, USER_ID_MUST_NOT_BE_NULL);
+    Assert.notNull(pageable, PAGEABLE_MUST_NOT_BE_NULL);
 
     List<ReviewWithLikeAndCommentCount> content =
         selectReviewWithLikeAndCommentCount(currentUserId)

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewCustomRepositoryImpl.java
@@ -40,7 +40,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
   }
 
   @Override
-  public Optional<ReviewWithLikeAndCommentCount> findReviewByReviewIdAndUserId(
+  public Optional<ReviewWithLikeAndCommentCount> findReviewByReviewId(
       Long reviewId, Long userId) {
 
     ReviewWithLikeAndCommentCount data =

--- a/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewSortType.java
+++ b/src/main/java/com/prgrms/artzip/review/domain/repository/ReviewSortType.java
@@ -4,11 +4,12 @@ import static com.prgrms.artzip.comment.domain.QComment.comment;
 import static com.prgrms.artzip.review.domain.QReview.review;
 import static com.prgrms.artzip.review.domain.QReviewLike.reviewLike;
 
+import com.prgrms.artzip.common.ErrorCode;
+import com.prgrms.artzip.common.error.exception.NotFoundException;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import java.util.Arrays;
-import java.util.Optional;
 
 public enum ReviewSortType {
 
@@ -28,10 +29,13 @@ public enum ReviewSortType {
     return new OrderSpecifier(direction, this.target);
   }
 
-  public static Optional<ReviewSortType> getReviewSortType(String property) {
+  public static ReviewSortType getReviewSortType(String property) {
     return Arrays.stream(ReviewSortType.values())
         .filter(reviewSortType -> reviewSortType.property.equals(property))
-        .findAny();
+        .findAny()
+        .orElseThrow(() -> {
+          throw new NotFoundException(ErrorCode.INVALID_REVIEW_SORT_TYPE);
+        });
   }
 
 }

--- a/src/main/java/com/prgrms/artzip/review/service/ReviewService.java
+++ b/src/main/java/com/prgrms/artzip/review/service/ReviewService.java
@@ -158,7 +158,7 @@ public class ReviewService {
   public PageResponse<ReviewsResponse> getReviews(
       final User user, final Long exhibitionId, final Pageable pageable) {
 
-    Page<ReviewWithLikeAndCommentCount> reviews = reviewRepository.findReviewsByExhibitionIdAndUserId(
+    Page<ReviewWithLikeAndCommentCount> reviews = reviewRepository.findReviews(
         exhibitionId, Objects.isNull(user) ? null : user.getId(), pageable);
 
     return new PageResponse<>(reviews.map(this::getReviewsResponse));
@@ -167,7 +167,7 @@ public class ReviewService {
   @Transactional(readOnly = true)
   public List<ReviewsResponseForExhibitionDetail> getReviewsForExhibition(Long userId,
       Long exhibitionId) {
-    List<ReviewWithLikeAndCommentCount> reviews = reviewRepository.findReviewsByExhibitionIdAndUserId(
+    List<ReviewWithLikeAndCommentCount> reviews = reviewRepository.findReviews(
         exhibitionId, Objects.isNull(userId) ? null : userId,
         PageRequest.of(0, 4, Sort.by("reviewLikeCount").descending())).getContent();
 

--- a/src/main/java/com/prgrms/artzip/review/service/ReviewService.java
+++ b/src/main/java/com/prgrms/artzip/review/service/ReviewService.java
@@ -134,7 +134,7 @@ public class ReviewService {
     Review review = reviewRepository.findById(reviewId)
         .orElseThrow(() -> new NotFoundException(ErrorCode.REVIEW_NOT_FOUND));
 
-    ReviewWithLikeAndCommentCount reviewData = reviewRepository.findReviewByReviewIdAndUserId(reviewId,
+    ReviewWithLikeAndCommentCount reviewData = reviewRepository.findReviewByReviewId(reviewId,
             Objects.isNull(user) ? null : user.getId())
         .orElseThrow(() -> new NotFoundException(ErrorCode.REVIEW_NOT_FOUND));
 

--- a/src/main/java/com/prgrms/artzip/review/service/ReviewService.java
+++ b/src/main/java/com/prgrms/artzip/review/service/ReviewService.java
@@ -134,7 +134,7 @@ public class ReviewService {
     Review review = reviewRepository.findById(reviewId)
         .orElseThrow(() -> new NotFoundException(ErrorCode.REVIEW_NOT_FOUND));
 
-    ReviewWithLikeAndCommentCount reviewData = reviewRepository.findByReviewIdAndUserId(reviewId,
+    ReviewWithLikeAndCommentCount reviewData = reviewRepository.findReviewByReviewIdAndUserId(reviewId,
             Objects.isNull(user) ? null : user.getId())
         .orElseThrow(() -> new NotFoundException(ErrorCode.REVIEW_NOT_FOUND));
 

--- a/src/test/java/com/prgrms/artzip/review/domain/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/prgrms/artzip/review/domain/repository/ReviewRepositoryTest.java
@@ -255,7 +255,7 @@ public class ReviewRepositoryTest {
     @Test
     @DisplayName("삭제된 리뷰를 조회하는 경우, null을 반환한다.")
     void testDeletedReview() {
-      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findByReviewIdAndUserId(
+      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewIdAndUserId(
           deletedReview.getId(), user1.getId());
 
       assertThat(result.isEmpty()).isTrue();
@@ -264,7 +264,7 @@ public class ReviewRepositoryTest {
     @Test
     @DisplayName("삭제되지 않은 리뷰를 조회하는 경우, 리뷰 정보를 반환한다.")
     void testNotDeletedReview() {
-      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findByReviewIdAndUserId(
+      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewIdAndUserId(
           publicReview1.getId(), user1.getId());
 
       assertThat(result.isPresent()).isTrue();
@@ -282,7 +282,7 @@ public class ReviewRepositoryTest {
     @Test
     @DisplayName("후기 작성자가 조회하는 경우, isPublic == true인 리뷰 정보를 반환한다.")
     void testPublicReviewWithWriter() {
-      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findByReviewIdAndUserId(
+      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewIdAndUserId(
           publicReview1.getId(), user1.getId());
 
       assertThat(result.isPresent()).isTrue();
@@ -300,7 +300,7 @@ public class ReviewRepositoryTest {
     @Test
     @DisplayName("후기 작성자가 조회하는 경우, isPublic == false인 리뷰 정보를 반환한다.")
     void testPrivateReviewWhitWriter() {
-      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findByReviewIdAndUserId(
+      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewIdAndUserId(
           privateReview.getId(), user1.getId());
 
       assertThat(result.isPresent()).isTrue();
@@ -318,7 +318,7 @@ public class ReviewRepositoryTest {
     @Test
     @DisplayName("user == null인 경우, isPublic == true인 리뷰 정보를 반환한다.")
     void testNullUser() {
-      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findByReviewIdAndUserId(
+      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewIdAndUserId(
           publicReview1.getId(), user1.getId());
 
       assertThat(result.isPresent()).isTrue();
@@ -336,7 +336,7 @@ public class ReviewRepositoryTest {
     @Test
     @DisplayName("user == null인 경우, isPublic == false인 리뷰 정보는 반환하지 않는다.")
     void testPrivateReview() {
-      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findByReviewIdAndUserId(
+      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewIdAndUserId(
           privateReview.getId(), null);
 
       assertThat(result.isEmpty()).isTrue();

--- a/src/test/java/com/prgrms/artzip/review/domain/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/prgrms/artzip/review/domain/repository/ReviewRepositoryTest.java
@@ -255,7 +255,7 @@ public class ReviewRepositoryTest {
     @Test
     @DisplayName("삭제된 리뷰를 조회하는 경우, null을 반환한다.")
     void testDeletedReview() {
-      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewIdAndUserId(
+      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewId(
           deletedReview.getId(), user1.getId());
 
       assertThat(result.isEmpty()).isTrue();
@@ -264,7 +264,7 @@ public class ReviewRepositoryTest {
     @Test
     @DisplayName("삭제되지 않은 리뷰를 조회하는 경우, 리뷰 정보를 반환한다.")
     void testNotDeletedReview() {
-      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewIdAndUserId(
+      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewId(
           publicReview1.getId(), user1.getId());
 
       assertThat(result.isPresent()).isTrue();
@@ -282,7 +282,7 @@ public class ReviewRepositoryTest {
     @Test
     @DisplayName("후기 작성자가 조회하는 경우, isPublic == true인 리뷰 정보를 반환한다.")
     void testPublicReviewWithWriter() {
-      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewIdAndUserId(
+      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewId(
           publicReview1.getId(), user1.getId());
 
       assertThat(result.isPresent()).isTrue();
@@ -300,7 +300,7 @@ public class ReviewRepositoryTest {
     @Test
     @DisplayName("후기 작성자가 조회하는 경우, isPublic == false인 리뷰 정보를 반환한다.")
     void testPrivateReviewWhitWriter() {
-      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewIdAndUserId(
+      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewId(
           privateReview.getId(), user1.getId());
 
       assertThat(result.isPresent()).isTrue();
@@ -318,7 +318,7 @@ public class ReviewRepositoryTest {
     @Test
     @DisplayName("user == null인 경우, isPublic == true인 리뷰 정보를 반환한다.")
     void testNullUser() {
-      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewIdAndUserId(
+      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewId(
           publicReview1.getId(), user1.getId());
 
       assertThat(result.isPresent()).isTrue();
@@ -336,7 +336,7 @@ public class ReviewRepositoryTest {
     @Test
     @DisplayName("user == null인 경우, isPublic == false인 리뷰 정보는 반환하지 않는다.")
     void testPrivateReview() {
-      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewIdAndUserId(
+      Optional<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewByReviewId(
           privateReview.getId(), null);
 
       assertThat(result.isEmpty()).isTrue();

--- a/src/test/java/com/prgrms/artzip/review/domain/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/prgrms/artzip/review/domain/repository/ReviewRepositoryTest.java
@@ -358,7 +358,7 @@ public class ReviewRepositoryTest {
       @DisplayName("userId == null인 경우, isLiked(좋아요 여부)는 조회되지 않는다.")
       void testUserIdIsNull() {
 
-        Page<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewsByExhibitionIdAndUserId(
+        Page<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviews(
             null, null, pageable);
 
         assertThat(result.getTotalPages()).isEqualTo(1);
@@ -396,7 +396,7 @@ public class ReviewRepositoryTest {
       @Test
       @DisplayName("userId != null인 경우, isLiked(좋아요 여부)도 함께 조회된다.")
       void testUserIdInNotNull() {
-        Page<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewsByExhibitionIdAndUserId(
+        Page<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviews(
             null, user1.getId(), pageable);
 
         assertThat(result.getTotalPages()).isEqualTo(1);
@@ -441,7 +441,7 @@ public class ReviewRepositoryTest {
       @DisplayName("userId == null인 경우, isLiked(좋아요 여부)는 조회되지 않는다.")
       void testUserIdIsNull() {
 
-        Page<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewsByExhibitionIdAndUserId(
+        Page<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviews(
             exhibitionAtBusan.getId(), null, pageable);
 
         assertThat(result.getTotalPages()).isEqualTo(1);
@@ -470,7 +470,7 @@ public class ReviewRepositoryTest {
       @Test
       @DisplayName("userId != null인 경우, isLiked(좋아요 여부)도 함께 조회된다.")
       void testUserIdInNotNull() {
-        Page<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviewsByExhibitionIdAndUserId(
+        Page<ReviewWithLikeAndCommentCount> result = reviewRepository.findReviews(
             exhibitionAtBusan.getId(), user1.getId(), pageable);
 
         assertThat(result.getTotalPages()).isEqualTo(1);

--- a/src/test/java/com/prgrms/artzip/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/prgrms/artzip/review/service/ReviewServiceTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.verify;
 
 import com.prgrms.artzip.comment.domain.Comment;
 import com.prgrms.artzip.comment.dto.projection.CommentSimpleProjection;
-import com.prgrms.artzip.comment.dto.response.CommentResponse;
 import com.prgrms.artzip.comment.dto.response.CommentResponseQ;
 import com.prgrms.artzip.comment.dto.response.CommentsResponse;
 import com.prgrms.artzip.comment.service.CommentService;
@@ -856,7 +855,7 @@ class ReviewServiceTest {
         // given
         given(reviewRepository.findById(reflectionReview.getId()))
             .willReturn(Optional.of(reflectionReview));
-        given(reviewRepository.findByReviewIdAndUserId(
+        given(reviewRepository.findReviewByReviewIdAndUserId(
             reflectionReview.getId(), null))
             .willReturn(Optional.of(reviewData));
         given(exhibitionRepository.findExhibitionForReview(
@@ -871,7 +870,7 @@ class ReviewServiceTest {
         reviewService.getReview(null, reflectionReview.getId());
 
         // then
-        verify(reviewRepository).findByReviewIdAndUserId(reflectionReview.getId(), null);
+        verify(reviewRepository).findReviewByReviewIdAndUserId(reflectionReview.getId(), null);
         verify(exhibitionRepository).findExhibitionForReview(
             null, reflectionReview.getExhibition().getId());
         verify(commentService).getCommentsByReviewId(
@@ -1031,7 +1030,7 @@ class ReviewServiceTest {
         // given
         given(reviewRepository.findById(reflectionReview.getId()))
             .willReturn(Optional.of(reflectionReview));
-        given(reviewRepository.findByReviewIdAndUserId(
+        given(reviewRepository.findReviewByReviewIdAndUserId(
             reflectionReview.getId(), reflectionUser.getId()))
             .willReturn(Optional.of(reviewData));
         given(exhibitionRepository.findExhibitionForReview(
@@ -1046,7 +1045,7 @@ class ReviewServiceTest {
         reviewService.getReview(reflectionUser, reflectionReview.getId());
 
         // then
-        verify(reviewRepository).findByReviewIdAndUserId(reflectionReview.getId(),
+        verify(reviewRepository).findReviewByReviewIdAndUserId(reflectionReview.getId(),
             reflectionUser.getId());
         verify(exhibitionRepository).findExhibitionForReview(
             reflectionUser.getId(), reflectionReview.getExhibition().getId());
@@ -1093,7 +1092,7 @@ class ReviewServiceTest {
 
         doReturn(Optional.of(privateReview)).when(reviewRepository).findById(privateReview.getId());
         doThrow(new NotFoundException(ErrorCode.REVIEW_NOT_FOUND))
-            .when(reviewRepository).findByReviewIdAndUserId(privateReview.getId(), null);
+            .when(reviewRepository).findReviewByReviewIdAndUserId(privateReview.getId(), null);
 
         // when
         // then
@@ -1109,7 +1108,7 @@ class ReviewServiceTest {
         // given
         doReturn(Optional.of(review)).when(reviewRepository).findById(review.getId());
         doReturn(Optional.of(reviewData))
-            .when(reviewRepository).findByReviewIdAndUserId(review.getId(), null);
+            .when(reviewRepository).findReviewByReviewIdAndUserId(review.getId(), null);
         doThrow(new NotFoundException(ErrorCode.EXHB_NOT_FOUND))
             .when(exhibitionRepository).findExhibitionForReview(any(), any());
 

--- a/src/test/java/com/prgrms/artzip/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/prgrms/artzip/review/service/ReviewServiceTest.java
@@ -1238,7 +1238,7 @@ class ReviewServiceTest {
             1L
         );
 
-        given(reviewRepository.findReviewsByExhibitionIdAndUserId(
+        given(reviewRepository.findReviews(
             reflectionExhibition.getId(), null, pageable))
             .willReturn(reflectionReviews);
         given(reviewRepository.findById(reflectionReviews.getContent().get(0).getReviewId()))
@@ -1248,7 +1248,7 @@ class ReviewServiceTest {
 
         reviewService.getReviews(null, reflectionExhibition.getId(), pageable);
 
-        verify(reviewRepository).findReviewsByExhibitionIdAndUserId(reflectionExhibition.getId(),
+        verify(reviewRepository).findReviews(reflectionExhibition.getId(),
             null, pageable);
         verify(reviewRepository, times(reflectionReviews.getContent().size())).findById(
             reflectionReview.getId());
@@ -1360,7 +1360,7 @@ class ReviewServiceTest {
             1L
         );
 
-        given(reviewRepository.findReviewsByExhibitionIdAndUserId(
+        given(reviewRepository.findReviews(
             reflectionExhibition.getId(), reflectionUser.getId(), pageable))
             .willReturn(reflectionReviews);
         given(reviewRepository.findById(reflectionReviews.getContent().get(0).getReviewId()))
@@ -1370,7 +1370,7 @@ class ReviewServiceTest {
 
         reviewService.getReviews(reflectionUser, reflectionExhibition.getId(), pageable);
 
-        verify(reviewRepository).findReviewsByExhibitionIdAndUserId(reflectionExhibition.getId(),
+        verify(reviewRepository).findReviews(reflectionExhibition.getId(),
             reflectionUser.getId(), pageable);
         verify(reviewRepository, times(reflectionReviews.getContent().size())).findById(
             reflectionReview.getId());
@@ -1404,7 +1404,7 @@ class ReviewServiceTest {
       void testReviewNotFoundException() {
         // given
         doReturn(reviews)
-            .when(reviewRepository).findReviewsByExhibitionIdAndUserId(
+            .when(reviewRepository).findReviews(
                 exhibition.getId(), null, pageable);
         doThrow(new NotFoundException(ErrorCode.REVIEW_NOT_FOUND))
             .when(reviewRepository).findById(any());
@@ -1535,7 +1535,7 @@ class ReviewServiceTest {
             1L
         );
 
-        given(reviewRepository.findReviewsByExhibitionIdAndUserId(
+        given(reviewRepository.findReviews(
             reflectionExhibition.getId(), null, pageable))
             .willReturn(reflectionReviews);
         given(reviewRepository.findById(reflectionReviews.getContent().get(0).getReviewId()))
@@ -1543,7 +1543,7 @@ class ReviewServiceTest {
 
         reviewService.getReviewsForExhibition(null, reflectionExhibition.getId());
 
-        verify(reviewRepository).findReviewsByExhibitionIdAndUserId(reflectionExhibition.getId(),
+        verify(reviewRepository).findReviews(reflectionExhibition.getId(),
             null, pageable);
         verify(reviewRepository, times(reflectionReviews.getContent().size())).findById(
             reflectionReview.getId());
@@ -1653,7 +1653,7 @@ class ReviewServiceTest {
             1L
         );
 
-        given(reviewRepository.findReviewsByExhibitionIdAndUserId(
+        given(reviewRepository.findReviews(
             reflectionExhibition.getId(), reflectionUser.getId(), pageable))
             .willReturn(reflectionReviews);
         given(reviewRepository.findById(reflectionReviews.getContent().get(0).getReviewId()))
@@ -1661,7 +1661,7 @@ class ReviewServiceTest {
 
         reviewService.getReviewsForExhibition(reflectionUser.getId(), reflectionExhibition.getId());
 
-        verify(reviewRepository).findReviewsByExhibitionIdAndUserId(reflectionExhibition.getId(),
+        verify(reviewRepository).findReviews(reflectionExhibition.getId(),
             reflectionUser.getId(), pageable);
         verify(reviewRepository, times(reflectionReviews.getContent().size())).findById(
             reflectionReview.getId());
@@ -1700,7 +1700,7 @@ class ReviewServiceTest {
       void testReviewNotFoundException() {
         // given
         doReturn(reviews)
-            .when(reviewRepository).findReviewsByExhibitionIdAndUserId(
+            .when(reviewRepository).findReviews(
                 exhibition.getId(), null, pageable);
         doThrow(new NotFoundException(ErrorCode.REVIEW_NOT_FOUND))
             .when(reviewRepository).findById(any());

--- a/src/test/java/com/prgrms/artzip/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/prgrms/artzip/review/service/ReviewServiceTest.java
@@ -855,7 +855,7 @@ class ReviewServiceTest {
         // given
         given(reviewRepository.findById(reflectionReview.getId()))
             .willReturn(Optional.of(reflectionReview));
-        given(reviewRepository.findReviewByReviewIdAndUserId(
+        given(reviewRepository.findReviewByReviewId(
             reflectionReview.getId(), null))
             .willReturn(Optional.of(reviewData));
         given(exhibitionRepository.findExhibitionForReview(
@@ -870,7 +870,7 @@ class ReviewServiceTest {
         reviewService.getReview(null, reflectionReview.getId());
 
         // then
-        verify(reviewRepository).findReviewByReviewIdAndUserId(reflectionReview.getId(), null);
+        verify(reviewRepository).findReviewByReviewId(reflectionReview.getId(), null);
         verify(exhibitionRepository).findExhibitionForReview(
             null, reflectionReview.getExhibition().getId());
         verify(commentService).getCommentsByReviewId(
@@ -1030,7 +1030,7 @@ class ReviewServiceTest {
         // given
         given(reviewRepository.findById(reflectionReview.getId()))
             .willReturn(Optional.of(reflectionReview));
-        given(reviewRepository.findReviewByReviewIdAndUserId(
+        given(reviewRepository.findReviewByReviewId(
             reflectionReview.getId(), reflectionUser.getId()))
             .willReturn(Optional.of(reviewData));
         given(exhibitionRepository.findExhibitionForReview(
@@ -1045,7 +1045,7 @@ class ReviewServiceTest {
         reviewService.getReview(reflectionUser, reflectionReview.getId());
 
         // then
-        verify(reviewRepository).findReviewByReviewIdAndUserId(reflectionReview.getId(),
+        verify(reviewRepository).findReviewByReviewId(reflectionReview.getId(),
             reflectionUser.getId());
         verify(exhibitionRepository).findExhibitionForReview(
             reflectionUser.getId(), reflectionReview.getExhibition().getId());
@@ -1092,7 +1092,7 @@ class ReviewServiceTest {
 
         doReturn(Optional.of(privateReview)).when(reviewRepository).findById(privateReview.getId());
         doThrow(new NotFoundException(ErrorCode.REVIEW_NOT_FOUND))
-            .when(reviewRepository).findReviewByReviewIdAndUserId(privateReview.getId(), null);
+            .when(reviewRepository).findReviewByReviewId(privateReview.getId(), null);
 
         // when
         // then
@@ -1108,7 +1108,7 @@ class ReviewServiceTest {
         // given
         doReturn(Optional.of(review)).when(reviewRepository).findById(review.getId());
         doReturn(Optional.of(reviewData))
-            .when(reviewRepository).findReviewByReviewIdAndUserId(review.getId(), null);
+            .when(reviewRepository).findReviewByReviewId(review.getId(), null);
         doThrow(new NotFoundException(ErrorCode.EXHB_NOT_FOUND))
             .when(exhibitionRepository).findExhibitionForReview(any(), any());
 


### PR DESCRIPTION
## 구현 내용
### 후기 정렬 조건 예외 처리
- `ReviewSortType`에 정의되지 않은 값에 대해 예외 처리
- 이와 관련한 에외 코드 추가
### 중복 코드 제거
- 같은 projection DTO를 반환하는 메소드의 select절과 from절을 private 메소드로 빼냄
### 코드 정리 및 메소드명 변경
- `eq(true)`, `eq(false)`를 `isTrue()`, `isFalse()`로 통일
- 너무 긴 메소드명을 짧게 줄임; 이름에 필수 파라미터 정보만 담도록 변경
  - `findByReviewIdAndUserId()` -> `findReviewByReviewId()`
  - `findReviewsByExhibitionIdAndUserId()` -> `findReviews()`
### `QueryDslCustomUtils`에 `nullSafeConditions()`구현
- nullSafeConditions()는 null parameter로 인해 모든 조건절이 null이 반환하는 경우, 항상 false가 되는 조건절을 반환하도록 하는 method
  ```java
  /**
   * If all conditions are null,
   * returns BooleanExpression that is always false
   * @param conditions
   * @return BooleanExpression
   */
  public static Predicate nullSafeConditions(Predicate... conditions) {
    BooleanBuilder booleanBuilder = new BooleanBuilder();
    for (Predicate condition : conditions) {
      booleanBuilder.and(condition);
    }
    return alwaysFalse().or(booleanBuilder);
  }
  ```
- CommentCustomRepositoryImpl.java에도 적용 가능
    ```java
  @Override
  public Page<CommentSimpleProjection> getCommentsByReviewIdQ(Long reviewId, Long userId,
      Pageable pageable) {
    List<CommentSimpleProjection> comments = queryFactory.select(
            Projections.fields(CommentSimpleProjection.class,
                
               ...

                new CaseBuilder()
                    .when(nullSafeConditions(commentLikeEqToUserId(userId)))    // .when(alwaysFalse().or(commentLikeEqToUserId(userId)))
                    .then(true)
                    .otherwise(false)
                    .as("isLiked"))
        ).from(comment)
        ...

   ```
### ReviewCustomRepository에 null값 검증 추가
- 각 메소드의 필수 파라미터에 대해 null값 검증을 추가함
- client쪽에 보내줄 예외가 아니기 때문에 `Assert.notNull()`사용
### 각 메소드에 주석 추가
- ReviewCustomRepository에 null값 검증을 추가하면서 null이면 안되는 파라미터에 대한 표시나 설명이 필요하다고 생각해서 추가함